### PR TITLE
feat: change ordering cutoff from 12:30 to 9:00 Vienna time

### DIFF
--- a/src/app/src-rn/__tests__/store/menuStore.test.ts
+++ b/src/app/src-rn/__tests__/store/menuStore.test.ts
@@ -47,7 +47,7 @@ jest.mock('../../store/orderStore', () => ({
   },
 }));
 
-import { useMenuStore } from '../../store/menuStore';
+import { useMenuStore, ORDERING_CUTOFF_MESSAGE } from '../../store/menuStore';
 import { useAuthStore } from '../../store/authStore';
 import { GourmetMenuCategory } from '../../types/menu';
 import { MENU_CACHE_VALIDITY_MS } from '../../utils/constants';
@@ -399,7 +399,7 @@ describe('menuStore', () => {
         // New order should be blocked
         expect(mockApi.addToCart).not.toHaveBeenCalled();
         // Error should be shown for the blocked new order
-        expect(useMenuStore.getState().error).toBe('Bestellung für heute geschlossen (Bestellschluss 12:30)');
+        expect(useMenuStore.getState().error).toBe(ORDERING_CUTOFF_MESSAGE);
       } finally {
         isOrderingCutoff.mockRestore();
       }

--- a/src/app/src-rn/__tests__/utils/dateUtils.test.ts
+++ b/src/app/src-rn/__tests__/utils/dateUtils.test.ts
@@ -115,16 +115,23 @@ describe('dateUtils', () => {
       jest.useRealTimers();
     });
 
-    it('returns false for today before 12:30 Vienna time', () => {
-      // Feb 10 2026, 10:00 Vienna (CET = UTC+1) -> UTC 09:00
-      jest.setSystemTime(new Date('2026-02-10T09:00:00Z'));
+    it('returns false for today before 09:00 Vienna time', () => {
+      // Feb 10 2026, 08:59 Vienna (CET = UTC+1) -> UTC 07:59
+      jest.setSystemTime(new Date('2026-02-10T07:59:00Z'));
       const menuDate = new Date(2026, 1, 10);
       expect(isOrderingCutoff(menuDate)).toBe(false);
     });
 
-    it('returns true for today after 12:30 Vienna time', () => {
-      // Feb 10 2026, 12:31 Vienna (CET = UTC+1) -> UTC 11:31
-      jest.setSystemTime(new Date('2026-02-10T11:31:00Z'));
+    it('returns true for today at 09:00 Vienna time', () => {
+      // Feb 10 2026, 09:00 Vienna (CET = UTC+1) -> UTC 08:00
+      jest.setSystemTime(new Date('2026-02-10T08:00:00Z'));
+      const menuDate = new Date(2026, 1, 10);
+      expect(isOrderingCutoff(menuDate)).toBe(true);
+    });
+
+    it('returns true for today after 09:00 Vienna time', () => {
+      // Feb 10 2026, 10:00 Vienna (CET = UTC+1) -> UTC 09:00
+      jest.setSystemTime(new Date('2026-02-10T09:00:00Z'));
       const menuDate = new Date(2026, 1, 10);
       expect(isOrderingCutoff(menuDate)).toBe(true);
     });
@@ -134,6 +141,20 @@ describe('dateUtils', () => {
       jest.setSystemTime(new Date('2026-02-10T13:00:00Z'));
       const futureDate = new Date(2026, 1, 11); // Feb 11
       expect(isOrderingCutoff(futureDate)).toBe(false);
+    });
+
+    it('returns true for today at 09:00 Vienna time (CEST / summer)', () => {
+      // Aug 10 2026, 09:00 Vienna CEST (UTC+2) -> UTC 07:00
+      jest.setSystemTime(new Date('2026-08-10T07:00:00Z'));
+      const menuDate = new Date(2026, 7, 10); // Aug 10
+      expect(isOrderingCutoff(menuDate)).toBe(true);
+    });
+
+    it('returns false for today before 09:00 Vienna time (CEST / summer)', () => {
+      // Aug 10 2026, 08:59 Vienna CEST (UTC+2) -> UTC 06:59
+      jest.setSystemTime(new Date('2026-08-10T06:59:00Z'));
+      const menuDate = new Date(2026, 7, 10);
+      expect(isOrderingCutoff(menuDate)).toBe(false);
     });
   });
 

--- a/src/app/src-rn/store/menuStore.ts
+++ b/src/app/src-rn/store/menuStore.ts
@@ -7,6 +7,7 @@ import { MENU_CACHE_VALIDITY_MS } from '../utils/constants';
 import { isSameDay, isOrderingCutoff, localDateKey } from '../utils/dateUtils';
 
 const MENU_CACHE_KEY = 'menus_items';
+export const ORDERING_CUTOFF_MESSAGE = 'Bestellung für heute geschlossen (Bestellschluss 9:00)';
 
 /** Serialize menu items for AsyncStorage (Date -> ISO string). */
 function serializeMenuItems(items: GourmetMenuItem[]): string {
@@ -226,7 +227,7 @@ export const useMenuStore = create<MenuState>((set, get) => ({
     const allowedNewOrders = newOrderItems.filter((i) => !isOrderingCutoff(i.date));
     const hasCutoffBlocked = allowedNewOrders.length < newOrderItems.length;
     if (hasCutoffBlocked && allowedNewOrders.length === 0 && cancellationPositionIds.length === 0) {
-      set({ error: 'Bestellung für heute geschlossen (Bestellschluss 12:30)' });
+      set({ error: ORDERING_CUTOFF_MESSAGE });
       return;
     }
 
@@ -247,7 +248,7 @@ export const useMenuStore = create<MenuState>((set, get) => ({
       items: optimisticItems,
       pendingOrders: new Set(),
       pendingCancellations: new Set(),
-      error: hasCutoffBlocked ? 'Bestellung für heute geschlossen (Bestellschluss 12:30)' : null,
+      error: hasCutoffBlocked ? ORDERING_CUTOFF_MESSAGE : null,
     });
 
     try {
@@ -274,7 +275,7 @@ export const useMenuStore = create<MenuState>((set, get) => ({
       set({
         orderProgress: null,
         // Restore cutoff warning (fetchMenus clears error)
-        error: hasCutoffBlocked ? 'Bestellung für heute geschlossen (Bestellschluss 12:30)' : null,
+        error: hasCutoffBlocked ? ORDERING_CUTOFF_MESSAGE : null,
       });
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Bestellung konnte nicht aufgegeben werden';

--- a/src/app/src-rn/utils/dateUtils.ts
+++ b/src/app/src-rn/utils/dateUtils.ts
@@ -87,12 +87,12 @@ function viennaToday(): Date {
 
 /**
  * Check if ordering is blocked for a given menu date.
- * Today's menu cannot be ordered after 12:30 Europe/Vienna time.
+ * Today's menu cannot be ordered after 09:00 Europe/Vienna time.
  * Future dates are never blocked.
  */
 export function isOrderingCutoff(menuDate: Date): boolean {
   if (!isSameDay(menuDate, viennaToday())) return false;
-  return viennaMinutes() >= 12 * 60 + 30;
+  return viennaMinutes() >= 9 * 60;
 }
 
 /**


### PR DESCRIPTION
Closes #24

## Summary
- Changed ordering cutoff from 12:30 to 9:00 Europe/Vienna time, matching the existing cancellation cutoff
- Updated error message from "Bestellschluss 12:30" to "Bestellschluss 9:00"
- Added CEST/summer timezone tests for ordering cutoff (parity with cancellation cutoff tests)

## Test Plan
- [x] All 245 tests pass
- [x] `isOrderingCutoff` tests updated for 9:00 threshold (including CET and CEST)
- [x] `menuStore` test assertion updated for new error message