### PR TITLE
feat: notify on new imported menus (#13)

### DIFF
--- a/docs/plans/2026-02-24-new-menu-notifications-design.md
+++ b/docs/plans/2026-02-24-new-menu-notifications-design.md
@@ -1,0 +1,96 @@
+# New Menu Notifications — Design
+
+**Issue:** [#13](https://github.com/radaiko/SnackPilot/issues/13) — Notification on new imported menus
+
+**Goal:** Notify the user (iOS + Android) when the canteen imports new or changed menus, so they don't miss ordering.
+
+**Architecture:** Background fetch periodically scrapes the menu page, compares against known menu fingerprints, and fires a local push notification if new/changed menus are detected. Foreground detection covers the case where background fetch hasn't run yet, showing an in-app toast instead.
+
+**Tech Stack:** `expo-notifications`, `expo-background-fetch`, `expo-task-manager`
+
+---
+
+## Detection Logic
+
+Track known menus as a `Map<string, string>` in AsyncStorage:
+- Key: menu ID
+- Value: content fingerprint (`title|subtitle|allergens` concatenated)
+
+On each menu fetch (background or foreground):
+1. Compute fingerprints for all fetched menus
+2. Compare against stored `knownMenus` map
+3. New ID → new menu. Same ID but different fingerprint → changed menu
+4. If any new/changed AND `notificationSent === false` → notify
+
+## Notification Behavior
+
+- **One notification per batch.** Once fired, `notificationSent = true`. No repeated notifications.
+- **Background:** OS local push notification (generic message: "New menus have been added. Open SnackPilot to check them out.")
+- **Foreground:** In-app toast/snackbar at top of Menus screen
+- **Acknowledgment:** Opening the Menus tab updates `knownMenus` with all current fingerprints and resets `notificationSent = false`
+- Tapping the OS notification deep-links to the Menus tab
+
+## Background Fetch
+
+- Registered at module load time via `TaskManager.defineTask()`
+- OS controls frequency (15 min to hours, depending on user app usage patterns)
+- Runs headless JS: reads credentials from secure storage → logs in → fetches menus → compares → notifies
+- If user is not logged in, task skips silently
+
+## Notification Permissions
+
+- Requested after first successful login (from root layout)
+- If denied, detection still runs but no notification fires. No re-prompting.
+- No user-facing settings toggle (YAGNI)
+
+## Foreground Detection
+
+- Runs on Menus tab focus, after `fetchMenus()` / `refreshAvailability()` completes
+- Same comparison logic as background
+- If new/changed menus AND `notificationSent === false` → show toast
+- Covers the case where background fetch hasn't run or the user opens the app first
+
+## Data Flow
+
+```
+BACKGROUND:
+  OS wakes app → backgroundMenuCheck task
+    → read credentials (secure storage)
+    → login to Gourmet
+    → fetch menus
+    → compute fingerprints
+    → compare against knownMenus (AsyncStorage)
+    → new/changed AND notificationSent === false?
+        → yes: fire local notification, set notificationSent = true
+        → no: done
+
+FOREGROUND:
+  Menus tab focus → fetchMenus()
+    → compute fingerprints
+    → compare against knownMenus (AsyncStorage)
+    → new/changed AND notificationSent === false?
+        → yes: show toast, set notificationSent = true
+        → no: done
+    → update knownMenus with all current fingerprints
+    → reset notificationSent = false
+```
+
+## File Changes
+
+**New files:**
+- `src/app/src-rn/utils/backgroundMenuCheck.ts` — background task definition, registration, fingerprint comparison, AsyncStorage helpers for `knownMenus` and `notificationSent`
+- `src/app/src-rn/components/NewMenuToast.tsx` — lightweight toast/snackbar component
+
+**Modified files:**
+- `src/app/app/_layout.tsx` — call `registerBackgroundMenuCheck()`, request notification permissions after login
+- `src/app/app/(tabs)/index.tsx` — foreground detection after menu fetch, show toast, update `knownMenus` on tab focus
+- `src/app/src-rn/store/menuStore.ts` — expose helper to compute menu fingerprints
+- `src/app/app.json` — add `expo-notifications`, `expo-background-fetch`, `expo-task-manager` plugins
+- `src/app/package.json` — new dependencies
+
+## Constraints
+
+- Web scraping logic is NOT modified — reuses existing `gourmetApi` and `gourmetClient`
+- No external server or push service needed — all local notifications
+- Mobile only (iOS + Android) — desktop and web are unaffected
+- Background fetch timing is OS-controlled and not guaranteed — foreground detection is the safety net

--- a/docs/plans/2026-02-24-new-menu-notifications.md
+++ b/docs/plans/2026-02-24-new-menu-notifications.md
@@ -1,0 +1,850 @@
+# New Menu Notifications — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Notify the user on iOS/Android when new or changed menus appear, via background fetch + local push notification, with an in-app toast fallback for foreground detection.
+
+**Architecture:** A shared fingerprint-comparison module (`menuFingerprint.ts`) is used by both a background fetch task and the foreground Menus screen. Background: `expo-background-fetch` + `expo-task-manager` periodically wake the app headlessly, login, scrape menus, compare fingerprints, and fire a local notification via `expo-notifications`. Foreground: after each menu fetch on the Menus tab, the same comparison runs and shows a toast if new menus are detected. Opening the Menus tab acknowledges all current menus.
+
+**Tech Stack:** `expo-notifications`, `expo-background-fetch`, `expo-task-manager`, AsyncStorage, existing `GourmetApi`
+
+**Design doc:** `docs/plans/2026-02-24-new-menu-notifications-design.md`
+
+---
+
+### Task 1: Install dependencies and configure plugins
+
+**Files:**
+- Modify: `src/app/package.json`
+- Modify: `src/app/app.json`
+
+**Step 1: Install expo packages**
+
+Run:
+```bash
+cd src/app && npx expo install expo-notifications expo-background-fetch expo-task-manager
+```
+
+**Step 2: Add plugins to `app.json`**
+
+In `src/app/app.json`, add the three plugins to the `plugins` array (after `"expo-font"`):
+
+```json
+"expo-background-fetch",
+"expo-task-manager",
+[
+  "expo-notifications",
+  {
+    "icon": "./assets/icons/icon-orange.png",
+    "color": "#FF6B35"
+  }
+]
+```
+
+**Step 3: Verify install**
+
+Run:
+```bash
+cd src/app && npx expo config --type public | grep -E "notifications|background-fetch|task-manager"
+```
+Expected: All three plugins listed.
+
+**Step 4: Commit**
+
+```bash
+git add src/app/package.json src/app/app.json src/app/package-lock.json
+git commit -m "chore: add expo-notifications, background-fetch, task-manager deps (#13)"
+```
+
+---
+
+### Task 2: Menu fingerprint module (TDD)
+
+This pure module computes and compares menu fingerprints. No Expo/RN dependencies — fully testable with Jest.
+
+**Files:**
+- Create: `src/app/src-rn/utils/menuFingerprint.ts`
+- Create: `src/app/src-rn/__tests__/utils/menuFingerprint.test.ts`
+
+**Step 1: Write failing tests**
+
+Create `src/app/src-rn/__tests__/utils/menuFingerprint.test.ts`:
+
+```typescript
+import {
+  computeFingerprints,
+  detectNewMenus,
+  serializeKnownMenus,
+  deserializeKnownMenus,
+} from '../../utils/menuFingerprint';
+import { GourmetMenuCategory } from '../../types/menu';
+import type { GourmetMenuItem } from '../../types/menu';
+
+function makeItem(overrides: Partial<GourmetMenuItem> = {}): GourmetMenuItem {
+  return {
+    id: 'menu-001',
+    day: new Date(2026, 1, 10),
+    title: 'MENU I',
+    subtitle: 'Schnitzel mit Reis',
+    allergens: ['A', 'G'],
+    available: true,
+    ordered: false,
+    category: GourmetMenuCategory.Menu1,
+    price: '',
+    ...overrides,
+  };
+}
+
+describe('menuFingerprint', () => {
+  describe('computeFingerprints', () => {
+    it('computes fingerprint from title, subtitle, allergens', () => {
+      const items = [makeItem()];
+      const fp = computeFingerprints(items);
+      expect(fp.size).toBe(1);
+      expect(fp.get('menu-001')).toBe('MENU I|Schnitzel mit Reis|A,G');
+    });
+
+    it('uses unique menu IDs as keys', () => {
+      const items = [
+        makeItem({ id: 'a' }),
+        makeItem({ id: 'b', title: 'MENU II' }),
+      ];
+      const fp = computeFingerprints(items);
+      expect(fp.size).toBe(2);
+      expect(fp.has('a')).toBe(true);
+      expect(fp.has('b')).toBe(true);
+    });
+
+    it('deduplicates same ID (last wins)', () => {
+      const items = [
+        makeItem({ id: 'a', subtitle: 'Mon' }),
+        makeItem({ id: 'a', subtitle: 'Tue' }),
+      ];
+      const fp = computeFingerprints(items);
+      expect(fp.size).toBe(1);
+      expect(fp.get('a')).toBe('MENU I|Tue|A,G');
+    });
+  });
+
+  describe('detectNewMenus', () => {
+    it('returns true when known map is empty', () => {
+      const current = new Map([['a', 'fp1']]);
+      expect(detectNewMenus(current, new Map())).toBe(true);
+    });
+
+    it('returns false when fingerprints match', () => {
+      const known = new Map([['a', 'fp1'], ['b', 'fp2']]);
+      const current = new Map([['a', 'fp1'], ['b', 'fp2']]);
+      expect(detectNewMenus(current, known)).toBe(false);
+    });
+
+    it('returns true when a new ID appears', () => {
+      const known = new Map([['a', 'fp1']]);
+      const current = new Map([['a', 'fp1'], ['b', 'fp2']]);
+      expect(detectNewMenus(current, known)).toBe(true);
+    });
+
+    it('returns true when fingerprint changes for existing ID', () => {
+      const known = new Map([['a', 'fp1']]);
+      const current = new Map([['a', 'fp2']]);
+      expect(detectNewMenus(current, known)).toBe(true);
+    });
+
+    it('returns false when menus are removed but remaining unchanged', () => {
+      const known = new Map([['a', 'fp1'], ['b', 'fp2']]);
+      const current = new Map([['a', 'fp1']]);
+      expect(detectNewMenus(current, known)).toBe(false);
+    });
+
+    it('returns false when both are empty', () => {
+      expect(detectNewMenus(new Map(), new Map())).toBe(false);
+    });
+  });
+
+  describe('serialization', () => {
+    it('round-trips through JSON', () => {
+      const original = new Map([['a', 'fp1'], ['b', 'fp2']]);
+      const json = serializeKnownMenus(original);
+      const restored = deserializeKnownMenus(json);
+      expect(restored).toEqual(original);
+    });
+
+    it('handles empty map', () => {
+      const json = serializeKnownMenus(new Map());
+      expect(deserializeKnownMenus(json)).toEqual(new Map());
+    });
+
+    it('returns empty map for invalid JSON', () => {
+      expect(deserializeKnownMenus('not json')).toEqual(new Map());
+    });
+
+    it('returns empty map for null', () => {
+      expect(deserializeKnownMenus(null)).toEqual(new Map());
+    });
+  });
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cd src/app && npx jest --testPathPattern="menuFingerprint" --verbose`
+Expected: FAIL — module not found.
+
+**Step 3: Implement the module**
+
+Create `src/app/src-rn/utils/menuFingerprint.ts`:
+
+```typescript
+import type { GourmetMenuItem } from '../types/menu';
+
+/**
+ * Compute a fingerprint map from menu items.
+ * Key: menu ID, Value: "title|subtitle|allergens" string.
+ * If multiple items share the same ID (same category, different days), last wins.
+ */
+export function computeFingerprints(items: GourmetMenuItem[]): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const item of items) {
+    map.set(item.id, `${item.title}|${item.subtitle}|${item.allergens.join(',')}`);
+  }
+  return map;
+}
+
+/**
+ * Detect whether any menu in `current` is new or changed compared to `known`.
+ * Returns true if there's at least one new ID or changed fingerprint.
+ */
+export function detectNewMenus(
+  current: Map<string, string>,
+  known: Map<string, string>,
+): boolean {
+  if (current.size === 0) return false;
+  if (known.size === 0) return true;
+
+  for (const [id, fingerprint] of current) {
+    const knownFp = known.get(id);
+    if (knownFp === undefined || knownFp !== fingerprint) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Serialize a fingerprint map to JSON for AsyncStorage. */
+export function serializeKnownMenus(map: Map<string, string>): string {
+  return JSON.stringify(Array.from(map.entries()));
+}
+
+/** Deserialize a fingerprint map from AsyncStorage JSON. */
+export function deserializeKnownMenus(json: string | null): Map<string, string> {
+  if (!json) return new Map();
+  try {
+    return new Map(JSON.parse(json));
+  } catch {
+    return new Map();
+  }
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cd src/app && npx jest --testPathPattern="menuFingerprint" --verbose`
+Expected: ALL PASS
+
+**Step 5: Run full test suite**
+
+Run: `cd src/app && npm test`
+Expected: ALL PASS (178+ tests)
+
+**Step 6: Commit**
+
+```bash
+git add src/app/src-rn/utils/menuFingerprint.ts src/app/src-rn/__tests__/utils/menuFingerprint.test.ts
+git commit -m "feat: add menu fingerprint detection module with tests (#13)"
+```
+
+---
+
+### Task 3: AsyncStorage helpers for known menus state (TDD)
+
+Persistence layer for the known-menus map and notification-sent flag.
+
+**Files:**
+- Create: `src/app/src-rn/utils/menuChangeStorage.ts`
+- Create: `src/app/src-rn/__tests__/utils/menuChangeStorage.test.ts`
+
+**Step 1: Write failing tests**
+
+Create `src/app/src-rn/__tests__/utils/menuChangeStorage.test.ts`:
+
+```typescript
+jest.mock('@react-native-async-storage/async-storage', () => {
+  const store: Record<string, string> = {};
+  return {
+    __esModule: true,
+    default: {
+      getItem: jest.fn((key: string) => Promise.resolve(store[key] ?? null)),
+      setItem: jest.fn((key: string, value: string) => { store[key] = value; return Promise.resolve(); }),
+      removeItem: jest.fn((key: string) => { delete store[key]; return Promise.resolve(); }),
+      clear: jest.fn(() => { Object.keys(store).forEach(k => delete store[k]); return Promise.resolve(); }),
+    },
+  };
+});
+
+import {
+  getKnownMenus,
+  setKnownMenus,
+  getNotificationSent,
+  setNotificationSent,
+} from '../../utils/menuChangeStorage';
+
+beforeEach(async () => {
+  const AsyncStorage = require('@react-native-async-storage/async-storage').default;
+  await AsyncStorage.clear();
+  jest.clearAllMocks();
+});
+
+describe('menuChangeStorage', () => {
+  describe('knownMenus', () => {
+    it('returns empty map when nothing stored', async () => {
+      const result = await getKnownMenus();
+      expect(result).toEqual(new Map());
+    });
+
+    it('persists and retrieves a map', async () => {
+      const map = new Map([['a', 'fp1'], ['b', 'fp2']]);
+      await setKnownMenus(map);
+      const result = await getKnownMenus();
+      expect(result).toEqual(map);
+    });
+  });
+
+  describe('notificationSent', () => {
+    it('returns false when nothing stored', async () => {
+      expect(await getNotificationSent()).toBe(false);
+    });
+
+    it('persists true', async () => {
+      await setNotificationSent(true);
+      expect(await getNotificationSent()).toBe(true);
+    });
+
+    it('persists false after true', async () => {
+      await setNotificationSent(true);
+      await setNotificationSent(false);
+      expect(await getNotificationSent()).toBe(false);
+    });
+  });
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cd src/app && npx jest --testPathPattern="menuChangeStorage" --verbose`
+Expected: FAIL — module not found.
+
+**Step 3: Implement**
+
+Create `src/app/src-rn/utils/menuChangeStorage.ts`:
+
+```typescript
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { serializeKnownMenus, deserializeKnownMenus } from './menuFingerprint';
+
+const KNOWN_MENUS_KEY = 'known_menu_fingerprints';
+const NOTIFICATION_SENT_KEY = 'menu_notification_sent';
+
+export async function getKnownMenus(): Promise<Map<string, string>> {
+  const json = await AsyncStorage.getItem(KNOWN_MENUS_KEY);
+  return deserializeKnownMenus(json);
+}
+
+export async function setKnownMenus(map: Map<string, string>): Promise<void> {
+  await AsyncStorage.setItem(KNOWN_MENUS_KEY, serializeKnownMenus(map));
+}
+
+export async function getNotificationSent(): Promise<boolean> {
+  const value = await AsyncStorage.getItem(NOTIFICATION_SENT_KEY);
+  return value === 'true';
+}
+
+export async function setNotificationSent(sent: boolean): Promise<void> {
+  await AsyncStorage.setItem(NOTIFICATION_SENT_KEY, String(sent));
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cd src/app && npx jest --testPathPattern="menuChangeStorage" --verbose`
+Expected: ALL PASS
+
+**Step 5: Run full test suite**
+
+Run: `cd src/app && npm test`
+Expected: ALL PASS
+
+**Step 6: Commit**
+
+```bash
+git add src/app/src-rn/utils/menuChangeStorage.ts src/app/src-rn/__tests__/utils/menuChangeStorage.test.ts
+git commit -m "feat: add AsyncStorage helpers for menu change tracking (#13)"
+```
+
+---
+
+### Task 4: Background menu check module
+
+This module defines the background fetch task and notification logic. It runs headlessly (no React, no hooks). It must be registered at module load time.
+
+**Files:**
+- Create: `src/app/src-rn/utils/backgroundMenuCheck.ts`
+
+**Step 1: Create the background menu check module**
+
+Create `src/app/src-rn/utils/backgroundMenuCheck.ts`:
+
+```typescript
+import * as BackgroundFetch from 'expo-background-fetch';
+import * as TaskManager from 'expo-task-manager';
+import * as Notifications from 'expo-notifications';
+import { Platform } from 'react-native';
+import { GourmetApi } from '../api/gourmetApi';
+import * as secureStorage from './secureStorage';
+import { computeFingerprints, detectNewMenus } from './menuFingerprint';
+import {
+  getKnownMenus,
+  setKnownMenus,
+  getNotificationSent,
+  setNotificationSent,
+} from './menuChangeStorage';
+
+const TASK_NAME = 'BACKGROUND_MENU_CHECK';
+
+const CREDENTIALS_KEY_USER = 'gourmet_username';
+const CREDENTIALS_KEY_PASS = 'gourmet_password';
+
+// Android notification channel
+if (Platform.OS === 'android') {
+  Notifications.setNotificationChannelAsync('menu-updates', {
+    name: 'Neue Menüs',
+    importance: Notifications.AndroidImportance.DEFAULT,
+  });
+}
+
+/**
+ * The background task. Runs headlessly — no React, no hooks.
+ * Logs in, fetches menus, compares fingerprints, fires notification if new.
+ */
+async function backgroundMenuCheckTask(): Promise<BackgroundFetch.BackgroundFetchResult> {
+  try {
+    // Read credentials
+    const username = await secureStorage.getItem(CREDENTIALS_KEY_USER);
+    const password = await secureStorage.getItem(CREDENTIALS_KEY_PASS);
+    if (!username || !password) {
+      return BackgroundFetch.BackgroundFetchResult.NoData;
+    }
+
+    // Check if we already sent a notification for the current batch
+    const alreadySent = await getNotificationSent();
+    if (alreadySent) {
+      return BackgroundFetch.BackgroundFetchResult.NoData;
+    }
+
+    // Login and fetch menus
+    const api = new GourmetApi();
+    await api.login(username, password);
+    const items = await api.getMenus();
+
+    // Compare fingerprints
+    const currentFingerprints = computeFingerprints(items);
+    const knownMenus = await getKnownMenus();
+    const hasNew = detectNewMenus(currentFingerprints, knownMenus);
+
+    if (hasNew) {
+      await Notifications.scheduleNotificationAsync({
+        content: {
+          title: 'Neue Menüs verfügbar',
+          body: 'Es gibt neue Menüs. Öffne SnackPilot um sie anzusehen.',
+          data: { screen: '/(tabs)' },
+          ...(Platform.OS === 'android' ? { channelId: 'menu-updates' } : {}),
+        },
+        trigger: null, // Fire immediately
+      });
+      await setNotificationSent(true);
+      return BackgroundFetch.BackgroundFetchResult.NewData;
+    }
+
+    return BackgroundFetch.BackgroundFetchResult.NoData;
+  } catch {
+    return BackgroundFetch.BackgroundFetchResult.Failed;
+  }
+}
+
+// Register the task at module load time (required by expo-task-manager)
+TaskManager.defineTask(TASK_NAME, async () => {
+  return backgroundMenuCheckTask();
+});
+
+/**
+ * Register the background fetch task with the OS.
+ * Call once from the root layout after login.
+ * Safe to call multiple times — re-registration is a no-op if already registered.
+ */
+export async function registerBackgroundMenuCheck(): Promise<void> {
+  if (Platform.OS === 'web') return;
+
+  const isRegistered = await TaskManager.isTaskRegisteredAsync(TASK_NAME);
+  if (isRegistered) return;
+
+  await BackgroundFetch.registerTaskAsync(TASK_NAME, {
+    minimumInterval: 15 * 60, // 15 minutes (OS may choose longer)
+    stopOnTerminate: false,
+    startOnBoot: true,
+  });
+}
+
+/**
+ * Request notification permissions. Call once after first login.
+ * Returns true if permissions granted.
+ */
+export async function requestNotificationPermissions(): Promise<boolean> {
+  if (Platform.OS === 'web') return false;
+
+  const { status: existing } = await Notifications.getPermissionsAsync();
+  if (existing === 'granted') return true;
+
+  const { status } = await Notifications.requestPermissionsAsync();
+  return status === 'granted';
+}
+```
+
+**Step 2: Verify no type errors**
+
+Run: `cd src/app && npx tsc --noEmit --pretty 2>&1 | head -20`
+Expected: No errors related to `backgroundMenuCheck.ts` (there may be pre-existing warnings).
+
+**Step 3: Run full test suite (ensure no side effects)**
+
+Run: `cd src/app && npm test`
+Expected: ALL PASS (background module isn't imported in tests yet, so no impact)
+
+**Step 4: Commit**
+
+```bash
+git add src/app/src-rn/utils/backgroundMenuCheck.ts
+git commit -m "feat: add background menu check task with notifications (#13)"
+```
+
+---
+
+### Task 5: NewMenuToast component
+
+A simple animated toast that slides in from the top and auto-dismisses.
+
+**Files:**
+- Create: `src/app/src-rn/components/NewMenuToast.tsx`
+
+**Step 1: Create the toast component**
+
+Create `src/app/src-rn/components/NewMenuToast.tsx`:
+
+```tsx
+import { useEffect, useRef } from 'react';
+import { Animated, StyleSheet, Text } from 'react-native';
+import { useTheme } from '../theme/useTheme';
+import { tintedBanner } from '../theme/platformStyles';
+import type { Colors } from '../theme/colors';
+
+interface NewMenuToastProps {
+  visible: boolean;
+  onDismiss: () => void;
+}
+
+const DISPLAY_DURATION = 4000;
+const ANIMATION_DURATION = 300;
+
+export function NewMenuToast({ visible, onDismiss }: NewMenuToastProps) {
+  const { colors } = useTheme();
+  const translateY = useRef(new Animated.Value(-100)).current;
+  const opacity = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    if (visible) {
+      Animated.parallel([
+        Animated.timing(translateY, {
+          toValue: 0,
+          duration: ANIMATION_DURATION,
+          useNativeDriver: true,
+        }),
+        Animated.timing(opacity, {
+          toValue: 1,
+          duration: ANIMATION_DURATION,
+          useNativeDriver: true,
+        }),
+      ]).start();
+
+      const timer = setTimeout(() => {
+        Animated.parallel([
+          Animated.timing(translateY, {
+            toValue: -100,
+            duration: ANIMATION_DURATION,
+            useNativeDriver: true,
+          }),
+          Animated.timing(opacity, {
+            toValue: 0,
+            duration: ANIMATION_DURATION,
+            useNativeDriver: true,
+          }),
+        ]).start(() => onDismiss());
+      }, DISPLAY_DURATION);
+
+      return () => clearTimeout(timer);
+    }
+  }, [visible, translateY, opacity, onDismiss]);
+
+  if (!visible) return null;
+
+  const styles = createStyles(colors);
+
+  return (
+    <Animated.View style={[styles.container, { transform: [{ translateY }], opacity }]}>
+      <Text style={styles.text}>Neue Menüs verfügbar!</Text>
+    </Animated.View>
+  );
+}
+
+const createStyles = (c: Colors) =>
+  StyleSheet.create({
+    container: {
+      position: 'absolute',
+      top: 0,
+      left: 16,
+      right: 16,
+      zIndex: 100,
+      padding: 12,
+      alignItems: 'center',
+      ...tintedBanner(c, c.glassPrimary),
+    },
+    text: {
+      fontSize: 14,
+      fontWeight: '600',
+      color: c.primary,
+    },
+  });
+```
+
+**Step 2: Verify no type errors**
+
+Run: `cd src/app && npx tsc --noEmit --pretty 2>&1 | head -20`
+Expected: No errors related to `NewMenuToast.tsx`.
+
+**Step 3: Commit**
+
+```bash
+git add src/app/src-rn/components/NewMenuToast.tsx
+git commit -m "feat: add NewMenuToast component (#13)"
+```
+
+---
+
+### Task 6: Wire up root layout — registration and permissions
+
+**Files:**
+- Modify: `src/app/app/_layout.tsx`
+
+**Step 1: Add imports**
+
+At the top of `src/app/app/_layout.tsx`, add after the existing imports:
+
+```typescript
+import { isNative } from '../src-rn/utils/platform';
+```
+
+Conditionally import the background module only on native (it uses expo-task-manager which is native-only):
+
+```typescript
+const backgroundMenuCheck = isNative()
+  ? require('../src-rn/utils/backgroundMenuCheck')
+  : null;
+```
+
+**Step 2: Add registration effect**
+
+Inside the `AppContent` component, after the existing `useEffect` that calls `loginWithSaved`, add:
+
+```typescript
+useEffect(() => {
+  if (!backgroundMenuCheck) return;
+  backgroundMenuCheck.registerBackgroundMenuCheck();
+  backgroundMenuCheck.requestNotificationPermissions();
+}, []);
+```
+
+**Step 3: Verify the app still runs**
+
+Run: `cd src/app && npm test`
+Expected: ALL PASS (the require is conditional, tests run in a jsdom/node env where `isNative()` returns false, so the native module won't be loaded)
+
+**Step 4: Commit**
+
+```bash
+git add src/app/app/_layout.tsx
+git commit -m "feat: register background menu check on app start (#13)"
+```
+
+---
+
+### Task 7: Wire up foreground detection in Menus screen
+
+**Files:**
+- Modify: `src/app/app/(tabs)/index.tsx`
+
+**Step 1: Add imports**
+
+At the top of `src/app/app/(tabs)/index.tsx`, add:
+
+```typescript
+import { computeFingerprints, detectNewMenus } from '../../src-rn/utils/menuFingerprint';
+import {
+  getKnownMenus,
+  setKnownMenus,
+  getNotificationSent,
+  setNotificationSent,
+} from '../../src-rn/utils/menuChangeStorage';
+import { NewMenuToast } from '../../src-rn/components/NewMenuToast';
+```
+
+Add `useState` to the existing React import:
+
+```typescript
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+```
+
+**Step 2: Add toast state and detection logic**
+
+Inside the `MenusScreen` component, after the `const { orders, fetchOrders } = useOrderStore();` line, add:
+
+```typescript
+const [showToast, setShowToast] = useState(false);
+```
+
+**Step 3: Add detection function to `triggerRefresh`**
+
+Replace the existing `triggerRefresh` callback with:
+
+```typescript
+const triggerRefresh = useCallback(() => {
+  const auth = useAuthStore.getState().status;
+  if (auth !== 'authenticated') return;
+
+  const { loadCachedMenus } = useMenuStore.getState();
+  const { loadCachedOrders } = useOrderStore.getState();
+
+  // Load cache first for instant display
+  Promise.all([loadCachedMenus(), loadCachedOrders()]).catch(() => {}).finally(() => {
+    const cached = useMenuStore.getState().items.length > 0;
+    const refreshPromise = cached ? refreshAvailability() : fetchMenus();
+
+    // After menu fetch completes, check for new menus
+    refreshPromise?.then(async () => {
+      try {
+        const currentItems = useMenuStore.getState().items;
+        if (currentItems.length === 0) return;
+
+        const currentFingerprints = computeFingerprints(currentItems);
+        const knownMenus = await getKnownMenus();
+        const notificationSent = await getNotificationSent();
+
+        if (detectNewMenus(currentFingerprints, knownMenus) && !notificationSent) {
+          setShowToast(true);
+          await setNotificationSent(true);
+        }
+
+        // Acknowledge: update known menus and reset notification flag
+        await setKnownMenus(currentFingerprints);
+        await setNotificationSent(false);
+      } catch {
+        // Silent — don't break menu loading for fingerprint errors
+      }
+    });
+
+    fetchOrders();
+  });
+}, [fetchMenus, refreshAvailability, fetchOrders]);
+```
+
+Note: `refreshAvailability()` and `fetchMenus()` both return `Promise<void>`. The detection runs after the menu data is available in the store.
+
+**Step 4: Add toast to the render output**
+
+In the mobile layout return (the non-`isWideLayout` branch), add the toast inside the container, just before the `DayNavigator`:
+
+```tsx
+<NewMenuToast visible={showToast} onDismiss={() => setShowToast(false)} />
+```
+
+Also add it in the `isWideLayout` branch, inside the container just before `desktopRow`:
+
+```tsx
+<NewMenuToast visible={showToast} onDismiss={() => setShowToast(false)} />
+```
+
+**Step 5: Run full test suite**
+
+Run: `cd src/app && npm test`
+Expected: ALL PASS
+
+**Step 6: Commit**
+
+```bash
+git add src/app/app/(tabs)/index.tsx
+git commit -m "feat: add foreground new-menu detection with toast (#13)"
+```
+
+---
+
+### Task 8: Verify on iOS Simulator
+
+**Step 1: Rebuild and run**
+
+Run: `cd src/app && npx expo run:ios`
+
+**Step 2: Verify notification permission prompt**
+
+On first launch after rebuild, iOS should prompt for notification permissions. Accept it.
+
+**Step 3: Verify toast on fresh data**
+
+1. Login with credentials
+2. Navigate to the Menus tab
+3. On the very first load (no known menus stored yet), the toast "Neue Menüs verfügbar!" should appear briefly
+4. Navigate away and back — toast should NOT appear (menus are now known)
+
+**Step 4: Verify background task registration**
+
+Check that the background task is registered by looking at console output in Xcode. The task `BACKGROUND_MENU_CHECK` should be registered.
+
+**Step 5: Verify no regressions**
+
+- Menu ordering still works
+- Menu display still works
+- Swipe gestures still work
+- All tabs are accessible
+
+---
+
+### Task 9: Verify on Android Emulator
+
+**Step 1: Rebuild and run**
+
+Run: `cd src/app && npx expo run:android`
+
+**Step 2: Verify notification channel**
+
+In Android Settings > Apps > SnackPilot > Notifications, the "Neue Menüs" channel should be listed.
+
+**Step 3: Verify same behavior as iOS**
+
+- Toast appears on first load
+- Toast does not reappear on subsequent navigations
+- Menu ordering and display work normally

--- a/src/app/app.json
+++ b/src/app/app.json
@@ -49,6 +49,13 @@
       "expo-secure-store",
       "expo-font",
       [
+        "expo-notifications",
+        {
+          "icon": "./assets/icons/icon-orange.png",
+          "color": "#FF6B35"
+        }
+      ],
+      [
         "@g9k/expo-dynamic-app-icon",
         {
           "emerald": {
@@ -91,7 +98,6 @@
           "isAndroidForegroundServiceEnabled": true
         }
       ],
-      "expo-notifications",
       "expo-background-task"
     ],
     "extra": {

--- a/src/app/app/(tabs)/index.tsx
+++ b/src/app/app/(tabs)/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Animated,
@@ -27,6 +27,14 @@ import { useTheme } from '../../src-rn/theme/useTheme';
 import { useDesktopLayout } from '../../src-rn/hooks/useDesktopLayout';
 import { Colors } from '../../src-rn/theme/colors';
 import { tintedBanner, buttonPrimary, fab as fabStyle } from '../../src-rn/theme/platformStyles';
+import { computeFingerprints, detectNewMenus } from '../../src-rn/utils/menuFingerprint';
+import {
+  getKnownMenus,
+  setKnownMenus,
+  getNotificationSent,
+  setNotificationSent,
+} from '../../src-rn/utils/menuChangeStorage';
+import { NewMenuToast } from '../../src-rn/components/NewMenuToast';
 
 const ORDER_PROGRESS_LABELS: Record<NonNullable<OrderProgress>, string> = {
   adding: 'Wird in den Warenkorb gelegt...',
@@ -73,6 +81,8 @@ export default function MenusScreen() {
 
   const { orders, fetchOrders } = useOrderStore();
 
+  const [showToast, setShowToast] = useState(false);
+
   const triggerRefresh = useCallback(() => {
     const auth = useAuthStore.getState().status;
     if (auth !== 'authenticated') return;
@@ -83,11 +93,30 @@ export default function MenusScreen() {
     // Load cache first for instant display
     Promise.all([loadCachedMenus(), loadCachedOrders()]).catch(() => {}).finally(() => {
       const cached = useMenuStore.getState().items.length > 0;
-      if (cached) {
-        refreshAvailability();
-      } else {
-        fetchMenus();
-      }
+      const refreshPromise = cached ? refreshAvailability() : fetchMenus();
+
+      // After menu fetch completes, check for new menus
+      refreshPromise?.then(async () => {
+        try {
+          const currentItems = useMenuStore.getState().items;
+          if (currentItems.length === 0) return;
+
+          const currentFingerprints = computeFingerprints(currentItems);
+          const knownMenus = await getKnownMenus();
+          const notificationSent = await getNotificationSent();
+
+          if (detectNewMenus(currentFingerprints, knownMenus) && !notificationSent) {
+            setShowToast(true);
+          }
+
+          // Acknowledge: update known menus and reset notification flag
+          await setKnownMenus(currentFingerprints);
+          await setNotificationSent(false);
+        } catch {
+          // Silent — don't break menu loading for fingerprint errors
+        }
+      });
+
       fetchOrders();
     });
   }, [fetchMenus, refreshAvailability, fetchOrders]);
@@ -312,6 +341,7 @@ export default function MenusScreen() {
   if (isWideLayout) {
     return (
       <View style={styles.container}>
+        <NewMenuToast visible={showToast} onDismiss={() => setShowToast(false)} />
         <View style={styles.desktopRow}>
           {dates.length > 0 && (
             <DateListPanel
@@ -337,6 +367,7 @@ export default function MenusScreen() {
 
   return (
     <View style={[styles.container, { paddingTop: insets.top }]}>
+      <NewMenuToast visible={showToast} onDismiss={() => setShowToast(false)} />
       {dates.length > 0 && (
         <DayNavigator
           dates={dates}

--- a/src/app/app/(tabs)/index.tsx
+++ b/src/app/app/(tabs)/index.tsx
@@ -107,6 +107,7 @@ export default function MenusScreen() {
 
           if (detectNewMenus(currentFingerprints, knownMenus) && !notificationSent) {
             setShowToast(true);
+            await setNotificationSent(true);
           }
 
           // Acknowledge: update known menus and reset notification flag

--- a/src/app/app/_layout.tsx
+++ b/src/app/app/_layout.tsx
@@ -27,6 +27,7 @@ const backgroundMenuCheck = isNative()
 function AppContent() {
   const gourmetLoginWithSaved = useAuthStore((s) => s.loginWithSaved);
   const ventopayLoginWithSaved = useVentopayAuthStore((s) => s.loginWithSaved);
+  const gourmetAuthStatus = useAuthStore((s) => s.status);
   const { colorScheme } = useTheme();
 
   useEffect(() => {
@@ -35,10 +36,10 @@ function AppContent() {
   }, [gourmetLoginWithSaved, ventopayLoginWithSaved]);
 
   useEffect(() => {
-    if (!backgroundMenuCheck) return;
+    if (!backgroundMenuCheck || gourmetAuthStatus !== 'authenticated') return;
     backgroundMenuCheck.registerBackgroundMenuCheck();
     backgroundMenuCheck.requestNotificationPermissions();
-  }, []);
+  }, [gourmetAuthStatus]);
 
   useEffect(() => {
     if (Platform.OS === 'web') {

--- a/src/app/app/_layout.tsx
+++ b/src/app/app/_layout.tsx
@@ -37,8 +37,14 @@ function AppContent() {
 
   useEffect(() => {
     if (!backgroundMenuCheck || gourmetAuthStatus !== 'authenticated') return;
-    backgroundMenuCheck.registerBackgroundMenuCheck();
-    backgroundMenuCheck.requestNotificationPermissions();
+    void (async () => {
+      try {
+        await backgroundMenuCheck.registerBackgroundMenuCheck();
+        await backgroundMenuCheck.requestNotificationPermissions();
+      } catch {
+        // Silent — background registration is best-effort
+      }
+    })();
   }, [gourmetAuthStatus]);
 
   useEffect(() => {

--- a/src/app/app/_layout.tsx
+++ b/src/app/app/_layout.tsx
@@ -20,6 +20,10 @@ import {
   enableNotifications,
 } from '../src-rn/utils/notificationService';
 
+const backgroundMenuCheck = isNative()
+  ? require('../src-rn/utils/backgroundMenuCheck')
+  : null;
+
 function AppContent() {
   const gourmetLoginWithSaved = useAuthStore((s) => s.loginWithSaved);
   const ventopayLoginWithSaved = useVentopayAuthStore((s) => s.loginWithSaved);
@@ -29,6 +33,12 @@ function AppContent() {
     gourmetLoginWithSaved();
     ventopayLoginWithSaved();
   }, [gourmetLoginWithSaved, ventopayLoginWithSaved]);
+
+  useEffect(() => {
+    if (!backgroundMenuCheck) return;
+    backgroundMenuCheck.registerBackgroundMenuCheck();
+    backgroundMenuCheck.requestNotificationPermissions();
+  }, []);
 
   useEffect(() => {
     if (Platform.OS === 'web') {

--- a/src/app/package-lock.json
+++ b/src/app/package-lock.json
@@ -3474,6 +3474,27 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@isaacs/balanced-match": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/brace-expansion": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
+      "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/balanced-match": "^4.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -6599,9 +6620,9 @@
       }
     },
     "node_modules/@react-native/codegen/node_modules/minimatch": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
-      "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -8038,24 +8059,12 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/brace-expansion/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/braces": {
@@ -11242,15 +11251,15 @@
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "10.2.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.3.tgz",
-      "integrity": "sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.2.tgz",
+      "integrity": "sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "@isaacs/brace-expansion": "^5.0.1"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -18292,12 +18301,12 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.7.tgz",
-      "integrity": "sha512-MOwgjc8tfrpn5QQEvjijjmDVtMw2oL88ugTevzxQnzRLm6l3fVEF2gzU0kYeYYKD8C66+IdGX6peJ4MyUlUnPg==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -19715,9 +19724,9 @@
       }
     },
     "node_modules/react-native/node_modules/minimatch": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
-      "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -20080,9 +20089,9 @@
       }
     },
     "node_modules/rimraf/node_modules/minimatch": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
-      "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -20959,9 +20968,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
-      "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"

--- a/src/app/src-rn/__tests__/utils/menuChangeStorage.test.ts
+++ b/src/app/src-rn/__tests__/utils/menuChangeStorage.test.ts
@@ -1,0 +1,58 @@
+jest.mock('@react-native-async-storage/async-storage', () => {
+  const store: Record<string, string> = {};
+  return {
+    __esModule: true,
+    default: {
+      getItem: jest.fn((key: string) => Promise.resolve(store[key] ?? null)),
+      setItem: jest.fn((key: string, value: string) => { store[key] = value; return Promise.resolve(); }),
+      removeItem: jest.fn((key: string) => { delete store[key]; return Promise.resolve(); }),
+      clear: jest.fn(() => { Object.keys(store).forEach(k => delete store[k]); return Promise.resolve(); }),
+    },
+  };
+});
+
+import {
+  getKnownMenus,
+  setKnownMenus,
+  getNotificationSent,
+  setNotificationSent,
+} from '../../utils/menuChangeStorage';
+
+beforeEach(async () => {
+  const AsyncStorage = require('@react-native-async-storage/async-storage').default;
+  await AsyncStorage.clear();
+  jest.clearAllMocks();
+});
+
+describe('menuChangeStorage', () => {
+  describe('knownMenus', () => {
+    it('returns empty map when nothing stored', async () => {
+      const result = await getKnownMenus();
+      expect(result).toEqual(new Map());
+    });
+
+    it('persists and retrieves a map', async () => {
+      const map = new Map([['a', 'fp1'], ['b', 'fp2']]);
+      await setKnownMenus(map);
+      const result = await getKnownMenus();
+      expect(result).toEqual(map);
+    });
+  });
+
+  describe('notificationSent', () => {
+    it('returns false when nothing stored', async () => {
+      expect(await getNotificationSent()).toBe(false);
+    });
+
+    it('persists true', async () => {
+      await setNotificationSent(true);
+      expect(await getNotificationSent()).toBe(true);
+    });
+
+    it('persists false after true', async () => {
+      await setNotificationSent(true);
+      await setNotificationSent(false);
+      expect(await getNotificationSent()).toBe(false);
+    });
+  });
+});

--- a/src/app/src-rn/__tests__/utils/menuChangeStorage.test.ts
+++ b/src/app/src-rn/__tests__/utils/menuChangeStorage.test.ts
@@ -6,7 +6,7 @@ jest.mock('@react-native-async-storage/async-storage', () => {
       getItem: jest.fn((key: string) => Promise.resolve(store[key] ?? null)),
       setItem: jest.fn((key: string, value: string) => { store[key] = value; return Promise.resolve(); }),
       removeItem: jest.fn((key: string) => { delete store[key]; return Promise.resolve(); }),
-      clear: jest.fn(() => { Object.keys(store).forEach(k => delete store[k]); return Promise.resolve(); }),
+      clear: jest.fn(() => { Object.keys(store).forEach((k) => { delete store[k]; }); return Promise.resolve(); }),
     },
   };
 });

--- a/src/app/src-rn/__tests__/utils/menuFingerprint.test.ts
+++ b/src/app/src-rn/__tests__/utils/menuFingerprint.test.ts
@@ -1,0 +1,112 @@
+import {
+  computeFingerprints,
+  detectNewMenus,
+  serializeKnownMenus,
+  deserializeKnownMenus,
+} from '../../utils/menuFingerprint';
+import { GourmetMenuCategory } from '../../types/menu';
+import type { GourmetMenuItem } from '../../types/menu';
+
+function makeItem(overrides: Partial<GourmetMenuItem> = {}): GourmetMenuItem {
+  return {
+    id: 'menu-001',
+    day: new Date(2026, 1, 10),
+    title: 'MENU I',
+    subtitle: 'Schnitzel mit Reis',
+    allergens: ['A', 'G'],
+    available: true,
+    ordered: false,
+    category: GourmetMenuCategory.Menu1,
+    price: '',
+    ...overrides,
+  };
+}
+
+describe('menuFingerprint', () => {
+  describe('computeFingerprints', () => {
+    it('computes fingerprint from title, subtitle, allergens', () => {
+      const items = [makeItem()];
+      const fp = computeFingerprints(items);
+      expect(fp.size).toBe(1);
+      expect(fp.get('menu-001')).toBe('MENU I|Schnitzel mit Reis|A,G');
+    });
+
+    it('uses unique menu IDs as keys', () => {
+      const items = [
+        makeItem({ id: 'a' }),
+        makeItem({ id: 'b', title: 'MENU II' }),
+      ];
+      const fp = computeFingerprints(items);
+      expect(fp.size).toBe(2);
+      expect(fp.has('a')).toBe(true);
+      expect(fp.has('b')).toBe(true);
+    });
+
+    it('deduplicates same ID (last wins)', () => {
+      const items = [
+        makeItem({ id: 'a', subtitle: 'Mon' }),
+        makeItem({ id: 'a', subtitle: 'Tue' }),
+      ];
+      const fp = computeFingerprints(items);
+      expect(fp.size).toBe(1);
+      expect(fp.get('a')).toBe('MENU I|Tue|A,G');
+    });
+  });
+
+  describe('detectNewMenus', () => {
+    it('returns true when known map is empty', () => {
+      const current = new Map([['a', 'fp1']]);
+      expect(detectNewMenus(current, new Map())).toBe(true);
+    });
+
+    it('returns false when fingerprints match', () => {
+      const known = new Map([['a', 'fp1'], ['b', 'fp2']]);
+      const current = new Map([['a', 'fp1'], ['b', 'fp2']]);
+      expect(detectNewMenus(current, known)).toBe(false);
+    });
+
+    it('returns true when a new ID appears', () => {
+      const known = new Map([['a', 'fp1']]);
+      const current = new Map([['a', 'fp1'], ['b', 'fp2']]);
+      expect(detectNewMenus(current, known)).toBe(true);
+    });
+
+    it('returns true when fingerprint changes for existing ID', () => {
+      const known = new Map([['a', 'fp1']]);
+      const current = new Map([['a', 'fp2']]);
+      expect(detectNewMenus(current, known)).toBe(true);
+    });
+
+    it('returns false when menus are removed but remaining unchanged', () => {
+      const known = new Map([['a', 'fp1'], ['b', 'fp2']]);
+      const current = new Map([['a', 'fp1']]);
+      expect(detectNewMenus(current, known)).toBe(false);
+    });
+
+    it('returns false when both are empty', () => {
+      expect(detectNewMenus(new Map(), new Map())).toBe(false);
+    });
+  });
+
+  describe('serialization', () => {
+    it('round-trips through JSON', () => {
+      const original = new Map([['a', 'fp1'], ['b', 'fp2']]);
+      const json = serializeKnownMenus(original);
+      const restored = deserializeKnownMenus(json);
+      expect(restored).toEqual(original);
+    });
+
+    it('handles empty map', () => {
+      const json = serializeKnownMenus(new Map());
+      expect(deserializeKnownMenus(json)).toEqual(new Map());
+    });
+
+    it('returns empty map for invalid JSON', () => {
+      expect(deserializeKnownMenus('not json')).toEqual(new Map());
+    });
+
+    it('returns empty map for null', () => {
+      expect(deserializeKnownMenus(null)).toEqual(new Map());
+    });
+  });
+});

--- a/src/app/src-rn/__tests__/utils/menuFingerprint.test.ts
+++ b/src/app/src-rn/__tests__/utils/menuFingerprint.test.ts
@@ -28,28 +28,39 @@ describe('menuFingerprint', () => {
       const items = [makeItem()];
       const fp = computeFingerprints(items);
       expect(fp.size).toBe(1);
-      expect(fp.get('menu-001')).toBe('MENU I|Schnitzel mit Reis|A,G');
+      expect(fp.get('menu-001|2026-02-10')).toBe('MENU I|Schnitzel mit Reis|A,G');
     });
 
-    it('uses unique menu IDs as keys', () => {
+    it('uses composite id|date as keys', () => {
       const items = [
         makeItem({ id: 'a' }),
         makeItem({ id: 'b', title: 'MENU II' }),
       ];
       const fp = computeFingerprints(items);
       expect(fp.size).toBe(2);
-      expect(fp.has('a')).toBe(true);
-      expect(fp.has('b')).toBe(true);
+      expect(fp.has('a|2026-02-10')).toBe(true);
+      expect(fp.has('b|2026-02-10')).toBe(true);
     });
 
-    it('deduplicates same ID (last wins)', () => {
+    it('same ID on different days produces separate entries', () => {
       const items = [
-        makeItem({ id: 'a', subtitle: 'Mon' }),
-        makeItem({ id: 'a', subtitle: 'Tue' }),
+        makeItem({ id: 'a', day: new Date(2026, 1, 10), subtitle: 'Mon' }),
+        makeItem({ id: 'a', day: new Date(2026, 1, 11), subtitle: 'Tue' }),
+      ];
+      const fp = computeFingerprints(items);
+      expect(fp.size).toBe(2);
+      expect(fp.get('a|2026-02-10')).toBe('MENU I|Mon|A,G');
+      expect(fp.get('a|2026-02-11')).toBe('MENU I|Tue|A,G');
+    });
+
+    it('deduplicates same ID and same day (last wins)', () => {
+      const items = [
+        makeItem({ id: 'a', subtitle: 'first' }),
+        makeItem({ id: 'a', subtitle: 'second' }),
       ];
       const fp = computeFingerprints(items);
       expect(fp.size).toBe(1);
-      expect(fp.get('a')).toBe('MENU I|Tue|A,G');
+      expect(fp.get('a|2026-02-10')).toBe('MENU I|second|A,G');
     });
   });
 

--- a/src/app/src-rn/components/NewMenuToast.tsx
+++ b/src/app/src-rn/components/NewMenuToast.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useRef } from 'react';
+import { Animated, StyleSheet, Text } from 'react-native';
+import { useTheme } from '../theme/useTheme';
+import { tintedBanner } from '../theme/platformStyles';
+import type { Colors } from '../theme/colors';
+
+interface NewMenuToastProps {
+  visible: boolean;
+  onDismiss: () => void;
+}
+
+const DISPLAY_DURATION = 4000;
+const ANIMATION_DURATION = 300;
+
+export function NewMenuToast({ visible, onDismiss }: NewMenuToastProps) {
+  const { colors } = useTheme();
+  const translateY = useRef(new Animated.Value(-100)).current;
+  const opacity = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    if (visible) {
+      Animated.parallel([
+        Animated.timing(translateY, {
+          toValue: 0,
+          duration: ANIMATION_DURATION,
+          useNativeDriver: true,
+        }),
+        Animated.timing(opacity, {
+          toValue: 1,
+          duration: ANIMATION_DURATION,
+          useNativeDriver: true,
+        }),
+      ]).start();
+
+      const timer = setTimeout(() => {
+        Animated.parallel([
+          Animated.timing(translateY, {
+            toValue: -100,
+            duration: ANIMATION_DURATION,
+            useNativeDriver: true,
+          }),
+          Animated.timing(opacity, {
+            toValue: 0,
+            duration: ANIMATION_DURATION,
+            useNativeDriver: true,
+          }),
+        ]).start(() => onDismiss());
+      }, DISPLAY_DURATION);
+
+      return () => clearTimeout(timer);
+    }
+  }, [visible, translateY, opacity, onDismiss]);
+
+  if (!visible) return null;
+
+  const styles = createStyles(colors);
+
+  return (
+    <Animated.View style={[styles.container, { transform: [{ translateY }], opacity }]}>
+      <Text style={styles.text}>Neue Menüs verfügbar!</Text>
+    </Animated.View>
+  );
+}
+
+const createStyles = (c: Colors) =>
+  StyleSheet.create({
+    container: {
+      position: 'absolute',
+      top: 0,
+      left: 16,
+      right: 16,
+      zIndex: 100,
+      padding: 12,
+      alignItems: 'center',
+      ...tintedBanner(c, c.glassPrimary),
+    },
+    text: {
+      fontSize: 14,
+      fontWeight: '600',
+      color: c.primary,
+    },
+  });

--- a/src/app/src-rn/components/NewMenuToast.tsx
+++ b/src/app/src-rn/components/NewMenuToast.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { Animated, StyleSheet, Text } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '../theme/useTheme';
 import { tintedBanner } from '../theme/platformStyles';
 import type { Colors } from '../theme/colors';
@@ -14,6 +15,7 @@ const ANIMATION_DURATION = 300;
 
 export function NewMenuToast({ visible, onDismiss }: NewMenuToastProps) {
   const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
   const translateY = useRef(new Animated.Value(-100)).current;
   const opacity = useRef(new Animated.Value(0)).current;
 
@@ -56,7 +58,7 @@ export function NewMenuToast({ visible, onDismiss }: NewMenuToastProps) {
   const styles = createStyles(colors);
 
   return (
-    <Animated.View style={[styles.container, { transform: [{ translateY }], opacity }]}>
+    <Animated.View style={[styles.container, { top: insets.top + 8, transform: [{ translateY }], opacity }]}>
       <Text style={styles.text}>Neue Menüs verfügbar!</Text>
     </Animated.View>
   );
@@ -66,7 +68,7 @@ const createStyles = (c: Colors) =>
   StyleSheet.create({
     container: {
       position: 'absolute',
-      top: 0,
+      top: 0, // Overridden by inline style with safe area inset
       left: 16,
       right: 16,
       zIndex: 100,

--- a/src/app/src-rn/store/authStore.ts
+++ b/src/app/src-rn/store/authStore.ts
@@ -3,11 +3,8 @@ import * as secureStorage from '../utils/secureStorage';
 import { GourmetApi } from '../api/gourmetApi';
 import { DemoGourmetApi } from '../api/demoGourmetApi';
 import { GourmetUserInfo } from '../types/menu';
-import { isDemoCredentials } from '../utils/constants';
+import { isDemoCredentials, CREDENTIALS_KEY_USER, CREDENTIALS_KEY_PASS } from '../utils/constants';
 import { useMenuStore } from './menuStore';
-
-const CREDENTIALS_KEY_USER = 'gourmet_username';
-const CREDENTIALS_KEY_PASS = 'gourmet_password';
 
 type AuthStatus = 'idle' | 'loading' | 'authenticated' | 'error' | 'no_credentials';
 

--- a/src/app/src-rn/utils/backgroundMenuCheck.ts
+++ b/src/app/src-rn/utils/backgroundMenuCheck.ts
@@ -1,0 +1,111 @@
+import * as BackgroundFetch from 'expo-background-fetch';
+import * as TaskManager from 'expo-task-manager';
+import * as Notifications from 'expo-notifications';
+import { Platform } from 'react-native';
+import { GourmetApi } from '../api/gourmetApi';
+import * as secureStorage from './secureStorage';
+import { computeFingerprints, detectNewMenus } from './menuFingerprint';
+import {
+  getKnownMenus,
+  getNotificationSent,
+  setNotificationSent,
+} from './menuChangeStorage';
+
+const TASK_NAME = 'BACKGROUND_MENU_CHECK';
+
+const CREDENTIALS_KEY_USER = 'gourmet_username';
+const CREDENTIALS_KEY_PASS = 'gourmet_password';
+
+// Android notification channel
+if (Platform.OS === 'android') {
+  Notifications.setNotificationChannelAsync('menu-updates', {
+    name: 'Neue Menüs',
+    importance: Notifications.AndroidImportance.DEFAULT,
+  });
+}
+
+/**
+ * The background task. Runs headlessly — no React, no hooks.
+ * Logs in, fetches menus, compares fingerprints, fires notification if new.
+ */
+async function backgroundMenuCheckTask(): Promise<BackgroundFetch.BackgroundFetchResult> {
+  try {
+    // Read credentials
+    const username = await secureStorage.getItem(CREDENTIALS_KEY_USER);
+    const password = await secureStorage.getItem(CREDENTIALS_KEY_PASS);
+    if (!username || !password) {
+      return BackgroundFetch.BackgroundFetchResult.NoData;
+    }
+
+    // Check if we already sent a notification for the current batch
+    const alreadySent = await getNotificationSent();
+    if (alreadySent) {
+      return BackgroundFetch.BackgroundFetchResult.NoData;
+    }
+
+    // Login and fetch menus
+    const api = new GourmetApi();
+    await api.login(username, password);
+    const items = await api.getMenus();
+
+    // Compare fingerprints
+    const currentFingerprints = computeFingerprints(items);
+    const knownMenus = await getKnownMenus();
+    const hasNew = detectNewMenus(currentFingerprints, knownMenus);
+
+    if (hasNew) {
+      await Notifications.scheduleNotificationAsync({
+        content: {
+          title: 'Neue Menüs verfügbar',
+          body: 'Es gibt neue Menüs. Öffne SnackPilot um sie anzusehen.',
+          data: { screen: '/(tabs)' },
+          ...(Platform.OS === 'android' ? { channelId: 'menu-updates' } : {}),
+        },
+        trigger: null, // Fire immediately
+      });
+      await setNotificationSent(true);
+      return BackgroundFetch.BackgroundFetchResult.NewData;
+    }
+
+    return BackgroundFetch.BackgroundFetchResult.NoData;
+  } catch {
+    return BackgroundFetch.BackgroundFetchResult.Failed;
+  }
+}
+
+// Register the task at module load time (required by expo-task-manager)
+TaskManager.defineTask(TASK_NAME, async () => {
+  return backgroundMenuCheckTask();
+});
+
+/**
+ * Register the background fetch task with the OS.
+ * Call once from the root layout after login.
+ * Safe to call multiple times — re-registration is a no-op if already registered.
+ */
+export async function registerBackgroundMenuCheck(): Promise<void> {
+  if (Platform.OS === 'web') return;
+
+  const isRegistered = await TaskManager.isTaskRegisteredAsync(TASK_NAME);
+  if (isRegistered) return;
+
+  await BackgroundFetch.registerTaskAsync(TASK_NAME, {
+    minimumInterval: 15 * 60, // 15 minutes (OS may choose longer)
+    stopOnTerminate: false,
+    startOnBoot: true,
+  });
+}
+
+/**
+ * Request notification permissions. Call once after first login.
+ * Returns true if permissions granted.
+ */
+export async function requestNotificationPermissions(): Promise<boolean> {
+  if (Platform.OS === 'web') return false;
+
+  const { status: existing } = await Notifications.getPermissionsAsync();
+  if (existing === 'granted') return true;
+
+  const { status } = await Notifications.requestPermissionsAsync();
+  return status === 'granted';
+}

--- a/src/app/src-rn/utils/backgroundMenuCheck.ts
+++ b/src/app/src-rn/utils/backgroundMenuCheck.ts
@@ -1,4 +1,4 @@
-import * as BackgroundFetch from 'expo-background-fetch';
+import * as BackgroundTask from 'expo-background-task';
 import * as TaskManager from 'expo-task-manager';
 import * as Notifications from 'expo-notifications';
 import { Platform } from 'react-native';
@@ -27,25 +27,25 @@ if (Platform.OS === 'android') {
  * The background task. Runs headlessly — no React, no hooks.
  * Logs in, fetches menus, compares fingerprints, fires notification if new.
  */
-async function backgroundMenuCheckTask(): Promise<BackgroundFetch.BackgroundFetchResult> {
+async function backgroundMenuCheckTask(): Promise<BackgroundTask.BackgroundTaskResult> {
   try {
     // Read credentials
     const username = await secureStorage.getItem(CREDENTIALS_KEY_USER);
     const password = await secureStorage.getItem(CREDENTIALS_KEY_PASS);
     if (!username || !password) {
-      return BackgroundFetch.BackgroundFetchResult.NoData;
+      return BackgroundTask.BackgroundTaskResult.Success;
     }
 
     // Skip background check for demo credentials — they are fake and
     // must never be sent to the live Gourmet server.
     if (isDemoCredentials(username, password)) {
-      return BackgroundFetch.BackgroundFetchResult.NoData;
+      return BackgroundTask.BackgroundTaskResult.Success;
     }
 
     // Check if we already sent a notification for the current batch
     const alreadySent = await getNotificationSent();
     if (alreadySent) {
-      return BackgroundFetch.BackgroundFetchResult.NoData;
+      return BackgroundTask.BackgroundTaskResult.Success;
     }
 
     // Login and fetch menus
@@ -70,12 +70,12 @@ async function backgroundMenuCheckTask(): Promise<BackgroundFetch.BackgroundFetc
       });
       await setNotificationSent(true);
       await setKnownMenus(currentFingerprints);
-      return BackgroundFetch.BackgroundFetchResult.NewData;
+      return BackgroundTask.BackgroundTaskResult.Success;
     }
 
-    return BackgroundFetch.BackgroundFetchResult.NoData;
+    return BackgroundTask.BackgroundTaskResult.Success;
   } catch {
-    return BackgroundFetch.BackgroundFetchResult.Failed;
+    return BackgroundTask.BackgroundTaskResult.Failed;
   }
 }
 
@@ -95,10 +95,8 @@ export async function registerBackgroundMenuCheck(): Promise<void> {
   const isRegistered = await TaskManager.isTaskRegisteredAsync(TASK_NAME);
   if (isRegistered) return;
 
-  await BackgroundFetch.registerTaskAsync(TASK_NAME, {
+  await BackgroundTask.registerTaskAsync(TASK_NAME, {
     minimumInterval: 15 * 60, // 15 minutes (OS may choose longer)
-    stopOnTerminate: false,
-    startOnBoot: true,
   });
 }
 

--- a/src/app/src-rn/utils/backgroundMenuCheck.ts
+++ b/src/app/src-rn/utils/backgroundMenuCheck.ts
@@ -4,17 +4,16 @@ import * as Notifications from 'expo-notifications';
 import { Platform } from 'react-native';
 import { GourmetApi } from '../api/gourmetApi';
 import * as secureStorage from './secureStorage';
+import { CREDENTIALS_KEY_USER, CREDENTIALS_KEY_PASS } from './constants';
 import { computeFingerprints, detectNewMenus } from './menuFingerprint';
 import {
   getKnownMenus,
+  setKnownMenus,
   getNotificationSent,
   setNotificationSent,
 } from './menuChangeStorage';
 
 const TASK_NAME = 'BACKGROUND_MENU_CHECK';
-
-const CREDENTIALS_KEY_USER = 'gourmet_username';
-const CREDENTIALS_KEY_PASS = 'gourmet_password';
 
 // Android notification channel
 if (Platform.OS === 'android') {
@@ -64,6 +63,7 @@ async function backgroundMenuCheckTask(): Promise<BackgroundFetch.BackgroundFetc
         trigger: null, // Fire immediately
       });
       await setNotificationSent(true);
+      await setKnownMenus(currentFingerprints);
       return BackgroundFetch.BackgroundFetchResult.NewData;
     }
 

--- a/src/app/src-rn/utils/backgroundMenuCheck.ts
+++ b/src/app/src-rn/utils/backgroundMenuCheck.ts
@@ -4,7 +4,7 @@ import * as Notifications from 'expo-notifications';
 import { Platform } from 'react-native';
 import { GourmetApi } from '../api/gourmetApi';
 import * as secureStorage from './secureStorage';
-import { CREDENTIALS_KEY_USER, CREDENTIALS_KEY_PASS } from './constants';
+import { CREDENTIALS_KEY_USER, CREDENTIALS_KEY_PASS, isDemoCredentials } from './constants';
 import { computeFingerprints, detectNewMenus } from './menuFingerprint';
 import {
   getKnownMenus,
@@ -33,6 +33,12 @@ async function backgroundMenuCheckTask(): Promise<BackgroundFetch.BackgroundFetc
     const username = await secureStorage.getItem(CREDENTIALS_KEY_USER);
     const password = await secureStorage.getItem(CREDENTIALS_KEY_PASS);
     if (!username || !password) {
+      return BackgroundFetch.BackgroundFetchResult.NoData;
+    }
+
+    // Skip background check for demo credentials — they are fake and
+    // must never be sent to the live Gourmet server.
+    if (isDemoCredentials(username, password)) {
       return BackgroundFetch.BackgroundFetchResult.NoData;
     }
 

--- a/src/app/src-rn/utils/constants.ts
+++ b/src/app/src-rn/utils/constants.ts
@@ -8,6 +8,10 @@ export const GOURMET_SETTINGS_URL = `${GOURMET_BASE_URL}/einstellungen/`;
 
 export const MENU_CACHE_VALIDITY_MS = 4 * 60 * 60 * 1000; // 4 hours
 
+// Secure storage keys for Gourmet credentials
+export const CREDENTIALS_KEY_USER = 'gourmet_username';
+export const CREDENTIALS_KEY_PASS = 'gourmet_password';
+
 // Ventopay (vending machines / POS billing)
 export const VENTOPAY_BASE_URL = 'https://my.ventopay.com/mocca.website';
 export const VENTOPAY_LOGIN_URL = `${VENTOPAY_BASE_URL}/Login.aspx`;

--- a/src/app/src-rn/utils/menuChangeStorage.ts
+++ b/src/app/src-rn/utils/menuChangeStorage.ts
@@ -1,0 +1,23 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { serializeKnownMenus, deserializeKnownMenus } from './menuFingerprint';
+
+const KNOWN_MENUS_KEY = 'known_menu_fingerprints';
+const NOTIFICATION_SENT_KEY = 'menu_notification_sent';
+
+export async function getKnownMenus(): Promise<Map<string, string>> {
+  const json = await AsyncStorage.getItem(KNOWN_MENUS_KEY);
+  return deserializeKnownMenus(json);
+}
+
+export async function setKnownMenus(map: Map<string, string>): Promise<void> {
+  await AsyncStorage.setItem(KNOWN_MENUS_KEY, serializeKnownMenus(map));
+}
+
+export async function getNotificationSent(): Promise<boolean> {
+  const value = await AsyncStorage.getItem(NOTIFICATION_SENT_KEY);
+  return value === 'true';
+}
+
+export async function setNotificationSent(sent: boolean): Promise<void> {
+  await AsyncStorage.setItem(NOTIFICATION_SENT_KEY, String(sent));
+}

--- a/src/app/src-rn/utils/menuFingerprint.ts
+++ b/src/app/src-rn/utils/menuFingerprint.ts
@@ -1,14 +1,17 @@
 import type { GourmetMenuItem } from '../types/menu';
+import { localDateKey } from './dateUtils';
 
 /**
  * Compute a fingerprint map from menu items.
- * Key: menu ID, Value: "title|subtitle|allergens" string.
- * If multiple items share the same ID (same category, different days), last wins.
+ * Key: "menuId|dateKey" composite, Value: "title|subtitle|allergens" string.
+ * Uses composite key because menu IDs are per-category, not per-item —
+ * the same ID appears on different days with different content.
  */
 export function computeFingerprints(items: GourmetMenuItem[]): Map<string, string> {
   const map = new Map<string, string>();
   for (const item of items) {
-    map.set(item.id, `${item.title}|${item.subtitle}|${item.allergens.join(',')}`);
+    const key = `${item.id}|${localDateKey(item.day)}`;
+    map.set(key, `${item.title}|${item.subtitle}|${item.allergens.join(',')}`);
   }
   return map;
 }

--- a/src/app/src-rn/utils/menuFingerprint.ts
+++ b/src/app/src-rn/utils/menuFingerprint.ts
@@ -1,0 +1,49 @@
+import type { GourmetMenuItem } from '../types/menu';
+
+/**
+ * Compute a fingerprint map from menu items.
+ * Key: menu ID, Value: "title|subtitle|allergens" string.
+ * If multiple items share the same ID (same category, different days), last wins.
+ */
+export function computeFingerprints(items: GourmetMenuItem[]): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const item of items) {
+    map.set(item.id, `${item.title}|${item.subtitle}|${item.allergens.join(',')}`);
+  }
+  return map;
+}
+
+/**
+ * Detect whether any menu in `current` is new or changed compared to `known`.
+ * Returns true if there's at least one new ID or changed fingerprint.
+ */
+export function detectNewMenus(
+  current: Map<string, string>,
+  known: Map<string, string>,
+): boolean {
+  if (current.size === 0) return false;
+  if (known.size === 0) return true;
+
+  for (const [id, fingerprint] of current) {
+    const knownFp = known.get(id);
+    if (knownFp === undefined || knownFp !== fingerprint) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Serialize a fingerprint map to JSON for AsyncStorage. */
+export function serializeKnownMenus(map: Map<string, string>): string {
+  return JSON.stringify(Array.from(map.entries()));
+}
+
+/** Deserialize a fingerprint map from AsyncStorage JSON. */
+export function deserializeKnownMenus(json: string | null): Map<string, string> {
+  if (!json) return new Map();
+  try {
+    return new Map(JSON.parse(json));
+  } catch {
+    return new Map();
+  }
+}


### PR DESCRIPTION
## Summary

- Adds background menu detection using `expo-background-fetch` + `expo-task-manager` that periodically scrapes menus and compares fingerprints against known state
- Fires a local push notification via `expo-notifications` when new or changed menus are detected (iOS + Android only)
- Shows an in-app toast on the Menus screen when foreground detection finds new menus (covers the case where background fetch hasn't run)
- One notification per batch — no repeated alerts. Opening the Menus tab acknowledges all current menus

## New dependencies

- `expo-notifications` — local notification scheduling and permissions
- `expo-background-fetch` — OS-managed periodic background execution
- `expo-task-manager` — background task registration (peer dep of background-fetch)

## New files

- `src/app/src-rn/utils/menuFingerprint.ts` — pure fingerprint computation and comparison logic
- `src/app/src-rn/utils/menuChangeStorage.ts` — AsyncStorage persistence for known menus + notification flag
- `src/app/src-rn/utils/backgroundMenuCheck.ts` — background task definition, notification firing, registration
- `src/app/src-rn/components/NewMenuToast.tsx` — animated slide-in toast component

## Detection logic

Menus are tracked by fingerprint: `title|subtitle|allergens` per menu ID. A new ID or changed fingerprint triggers detection. Both background and foreground paths use the same comparison module.

## Test plan

- [ ] Verify 260 tests pass (`cd src/app && npm test`)
- [ ] Build on iOS (`npx expo run:ios`), verify notification permission prompt after login
- [ ] Verify toast appears on first menu load (all menus are "new")
- [ ] Navigate away and back — toast should NOT reappear
- [ ] Build on Android (`npx expo run:android`), verify `menu-updates` notification channel exists
- [ ] Verify desktop/web builds are unaffected (notification code is gated behind `isNative()`)

Closes #13