### PR TITLE
fix: block ordering and cancellation for past dates

### DIFF
--- a/src/app/src-rn/__tests__/utils/dateUtils.test.ts
+++ b/src/app/src-rn/__tests__/utils/dateUtils.test.ts
@@ -143,6 +143,20 @@ describe('dateUtils', () => {
       expect(isOrderingCutoff(futureDate)).toBe(false);
     });
 
+    it('returns true for a past date', () => {
+      // Current time: Feb 10 2026, 08:00 Vienna (before cutoff) -> UTC 07:00
+      jest.setSystemTime(new Date('2026-02-10T07:00:00Z'));
+      const pastDate = new Date(2026, 1, 9); // Feb 9
+      expect(isOrderingCutoff(pastDate)).toBe(true);
+    });
+
+    it('returns true for a past date even well before cutoff time', () => {
+      // Current time: Feb 10 2026, 06:00 Vienna -> UTC 05:00
+      jest.setSystemTime(new Date('2026-02-10T05:00:00Z'));
+      const pastDate = new Date(2026, 1, 8); // Feb 8
+      expect(isOrderingCutoff(pastDate)).toBe(true);
+    });
+
     it('returns true for today at 09:00 Vienna time (CEST / summer)', () => {
       // Aug 10 2026, 09:00 Vienna CEST (UTC+2) -> UTC 07:00
       jest.setSystemTime(new Date('2026-08-10T07:00:00Z'));
@@ -241,6 +255,20 @@ describe('dateUtils', () => {
       jest.setSystemTime(new Date('2026-02-10T13:00:00Z'));
       const futureDate = new Date(2026, 1, 11); // Feb 11
       expect(isCancellationCutoff(futureDate)).toBe(false);
+    });
+
+    it('returns true for a past date', () => {
+      // Current time: Feb 10 2026, 08:00 Vienna (before cutoff) -> UTC 07:00
+      jest.setSystemTime(new Date('2026-02-10T07:00:00Z'));
+      const pastDate = new Date(2026, 1, 9); // Feb 9
+      expect(isCancellationCutoff(pastDate)).toBe(true);
+    });
+
+    it('returns true for a past date even well before cutoff time', () => {
+      // Current time: Feb 10 2026, 06:00 Vienna -> UTC 05:00
+      jest.setSystemTime(new Date('2026-02-10T05:00:00Z'));
+      const pastDate = new Date(2026, 1, 8); // Feb 8
+      expect(isCancellationCutoff(pastDate)).toBe(true);
     });
 
     it('returns true for today at 09:00 Vienna time (CEST / summer)', () => {

--- a/src/app/src-rn/utils/dateUtils.ts
+++ b/src/app/src-rn/utils/dateUtils.ts
@@ -87,21 +87,27 @@ function viennaToday(): Date {
 
 /**
  * Check if ordering is blocked for a given menu date.
+ * Past dates are always blocked.
  * Today's menu cannot be ordered after 09:00 Europe/Vienna time.
  * Future dates are never blocked.
  */
 export function isOrderingCutoff(menuDate: Date): boolean {
-  if (!isSameDay(menuDate, viennaToday())) return false;
+  const today = viennaToday();
+  if (menuDate < today) return true;
+  if (!isSameDay(menuDate, today)) return false;
   return viennaMinutes() >= 9 * 60;
 }
 
 /**
  * Check if cancellation is blocked for a given order date.
+ * Past dates are always blocked.
  * Today's order cannot be cancelled after 09:00 Europe/Vienna time.
  * Future dates are never blocked.
  */
 export function isCancellationCutoff(orderDate: Date): boolean {
-  if (!isSameDay(orderDate, viennaToday())) return false;
+  const today = viennaToday();
+  if (orderDate < today) return true;
+  if (!isSameDay(orderDate, today)) return false;
   return viennaMinutes() >= 9 * 60;
 }
 


### PR DESCRIPTION
## Summary
- `isOrderingCutoff` and `isCancellationCutoff` now return `true` for dates before today (Vienna time), blocking orders and cancellations for past dates
- Previously only today-after-9:00 was blocked; past dates were treated as unblocked

Closes #30

## Test plan
- [x] 4 new tests for past date blocking (both functions, near and far past)
- [x] All 249 existing tests pass