### PR TITLE
feat: daily order reminder notifications (#31)

### DIFF
--- a/docs/plans/2026-02-24-new-menu-notifications-design.md
+++ b/docs/plans/2026-02-24-new-menu-notifications-design.md
@@ -52,7 +52,7 @@ On each menu fetch (background or foreground):
 
 ## Data Flow
 
-```
+```text
 BACKGROUND:
   OS wakes app → backgroundMenuCheck task
     → read credentials (secure storage)

--- a/docs/plans/2026-02-25-daily-order-reminder-design.md
+++ b/docs/plans/2026-02-25-daily-order-reminder-design.md
@@ -7,7 +7,7 @@
 
 A scheduled local notification that fires once daily at a user-configured time, showing what the user has ordered today. Piggybacks on the existing `BACKGROUND_ORDER_SYNC_TASK` infrastructure. Native-only (iOS + Android), web stubs for desktop.
 
-## Decisions
+### Decisions
 
 - **MVP scope**: One-time local notification (not Live Activities / persistent widgets). Live Activities deferred to future iteration.
 - **No default time**: User must explicitly enable and configure the reminder time in settings.
@@ -18,7 +18,7 @@ A scheduled local notification that fires once daily at a user-configured time, 
 - **Tap action**: Opens the Orders tab.
 - **Settings grouping**: Location notifications and this reminder share a unified "Benachrichtigungen" section.
 
-## Data Flow
+### Data Flow
 
 ```
 BACKGROUND_ORDER_SYNC_TASK runs (~15 min interval)
@@ -35,7 +35,7 @@ BACKGROUND_ORDER_SYNC_TASK runs (~15 min interval)
 
 The `dailyReminderSentDate` resets naturally — when the date changes, today no longer matches the stored date.
 
-## Storage
+### Storage
 
 New AsyncStorage keys (in new `reminderStorage.ts`, following `menuChangeStorage.ts` pattern):
 
@@ -46,7 +46,7 @@ New AsyncStorage keys (in new `reminderStorage.ts`, following `menuChangeStorage
 | `daily_reminder_minute` | `"0"` - `"45"` | User-configured minute (15-min increments) |
 | `daily_reminder_sent_date` | `"YYYY-MM-DD"` | Last date notification was sent (prevents duplicates) |
 
-## Notification Content
+### Notification Content
 
 - **Title**: "Deine Bestellung heute"
 - **Body**: All orders joined with newlines, e.g.:
@@ -57,7 +57,7 @@ New AsyncStorage keys (in new `reminderStorage.ts`, following `menuChangeStorage
 - **Channel**: `order-reminders` (existing Android channel from location notifications)
 - **Tap action**: Deep link to `/(tabs)/orders`
 
-## Settings UI
+### Settings UI
 
 The existing "Standort-Benachrichtigungen" section becomes "Benachrichtigungen" with two sub-features:
 
@@ -79,7 +79,7 @@ The existing "Standort-Benachrichtigungen" section becomes "Benachrichtigungen" 
 
 Enabling the toggle requests notification permissions if not already granted. Section is only shown on native (`isNative()`).
 
-## Files to Create/Modify
+### Files to Create/Modify
 
 | File | Action |
 |------|--------|
@@ -90,7 +90,7 @@ Enabling the toggle requests notification permissions if not already granted. Se
 | `__tests__/utils/reminderStorage.test.ts` | **New** — tests for storage helpers |
 | `__tests__/utils/notificationTasks.test.ts` | **Modify** — add test cases for reminder logic |
 
-## Out of Scope
+### Out of Scope
 
 - No new background task registration (reuses existing)
 - No new permissions beyond what's already requested

--- a/docs/plans/2026-02-25-daily-order-reminder-design.md
+++ b/docs/plans/2026-02-25-daily-order-reminder-design.md
@@ -1,0 +1,98 @@
+# Daily Order Reminder Notification — Design
+
+**Issue**: #31
+**Date**: 2026-02-25
+
+## Overview
+
+A scheduled local notification that fires once daily at a user-configured time, showing what the user has ordered today. Piggybacks on the existing `BACKGROUND_ORDER_SYNC_TASK` infrastructure. Native-only (iOS + Android), web stubs for desktop.
+
+## Decisions
+
+- **MVP scope**: One-time local notification (not Live Activities / persistent widgets). Live Activities deferred to future iteration.
+- **No default time**: User must explicitly enable and configure the reminder time in settings.
+- **No order = no notification**: Silent skip when there's no order for today.
+- **Reuse existing background task**: The `BACKGROUND_ORDER_SYNC_TASK` (~15 min interval) already runs and loads orders. Add a time-window check for the configured reminder time.
+- **Time picker granularity**: 15-minute increments (e.g., 11:00, 11:15, 11:30, 11:45).
+- **Multiple orders**: Single notification listing all orders for the day.
+- **Tap action**: Opens the Orders tab.
+- **Settings grouping**: Location notifications and this reminder share a unified "Benachrichtigungen" section.
+
+## Data Flow
+
+```
+BACKGROUND_ORDER_SYNC_TASK runs (~15 min interval)
+  -> read reminderEnabled + reminderHour + reminderMinute from AsyncStorage
+  -> if disabled -> skip
+  -> check viennaMinutes() within +/-15 min of configured time
+  -> load cached orders (already done by existing task)
+  -> filter for today's orders
+  -> if no orders today -> skip
+  -> if already sent today (dailyReminderSentDate === today) -> skip
+  -> fire notification with all today's orders
+  -> set dailyReminderSentDate = today
+```
+
+The `dailyReminderSentDate` resets naturally — when the date changes, today no longer matches the stored date.
+
+## Storage
+
+New AsyncStorage keys (in new `reminderStorage.ts`, following `menuChangeStorage.ts` pattern):
+
+| Key | Type | Purpose |
+|-----|------|---------|
+| `daily_reminder_enabled` | `"true"` / `"false"` | Feature toggle |
+| `daily_reminder_hour` | `"0"` - `"23"` | User-configured hour |
+| `daily_reminder_minute` | `"0"` - `"45"` | User-configured minute (15-min increments) |
+| `daily_reminder_sent_date` | `"YYYY-MM-DD"` | Last date notification was sent (prevents duplicates) |
+
+## Notification Content
+
+- **Title**: "Deine Bestellung heute"
+- **Body**: All orders joined with newlines, e.g.:
+  ```
+  MENU II - Wiener Schnitzel
+  SUPPE & SALAT - Tomatensuppe
+  ```
+- **Channel**: `order-reminders` (existing Android channel from location notifications)
+- **Tap action**: Deep link to `/(tabs)/orders`
+
+## Settings UI
+
+The existing "Standort-Benachrichtigungen" section becomes "Benachrichtigungen" with two sub-features:
+
+```
++-- Benachrichtigungen -------------------------+
+|                                               |
+|  Bestell-Erinnerung                           |
+|  [Toggle: Ein/Aus]                            |
+|  (when enabled:)                              |
+|  Uhrzeit: [11:00 v] (15-min picker)          |
+|                                               |
+|  -- separator --                              |
+|                                               |
+|  Standort-Benachrichtigungen                  |
+|  (existing location UI unchanged)             |
+|                                               |
++-----------------------------------------------+
+```
+
+Enabling the toggle requests notification permissions if not already granted. Section is only shown on native (`isNative()`).
+
+## Files to Create/Modify
+
+| File | Action |
+|------|--------|
+| `src-rn/utils/reminderStorage.ts` | **New** — AsyncStorage helpers for reminder settings + sent flag |
+| `src-rn/utils/notificationTasks.ts` | **Modify** — add daily reminder check to `BACKGROUND_ORDER_SYNC_TASK` handler |
+| `src-rn/utils/constants.ts` | **Modify** — add default reminder constants if needed |
+| `app/(tabs)/settings.tsx` | **Modify** — restructure into "Benachrichtigungen" section, add reminder toggle + time picker |
+| `__tests__/utils/reminderStorage.test.ts` | **New** — tests for storage helpers |
+| `__tests__/utils/notificationTasks.test.ts` | **Modify** — add test cases for reminder logic |
+
+## Out of Scope
+
+- No new background task registration (reuses existing)
+- No new permissions beyond what's already requested
+- No foreground/in-app reminder (background notification only)
+- No Live Activities (deferred to future iteration)

--- a/docs/plans/2026-02-25-daily-order-reminder.md
+++ b/docs/plans/2026-02-25-daily-order-reminder.md
@@ -1,0 +1,857 @@
+# Daily Order Reminder Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a daily local notification showing today's ordered meals at a user-configured time.
+
+**Architecture:** Extends the existing `BACKGROUND_ORDER_SYNC_TASK` with a daily reminder check. New `reminderStorage.ts` manages settings and dedup state via AsyncStorage. Settings UI adds a toggle + 15-min-increment time picker under a unified "Benachrichtigungen" section. Native-only (iOS + Android), web stubs via platform extensions.
+
+**Tech Stack:** expo-notifications (already installed on feature/issue-13-menu-notifications branch), AsyncStorage, Zustand stores, React Native
+
+**Base branch:** `feature/issue-13-menu-notifications` (contains all notification infrastructure)
+
+---
+
+### Task 1: Reminder Storage Module
+
+**Files:**
+- Create: `src/app/src-rn/utils/reminderStorage.ts`
+- Test: `src/app/src-rn/__tests__/utils/reminderStorage.test.ts`
+
+**Step 1: Write the failing tests**
+
+Create `src/app/src-rn/__tests__/utils/reminderStorage.test.ts`:
+
+```typescript
+jest.mock('@react-native-async-storage/async-storage', () => {
+  const store: Record<string, string> = {};
+  return {
+    __esModule: true,
+    default: {
+      getItem: jest.fn((key: string) => Promise.resolve(store[key] ?? null)),
+      setItem: jest.fn((key: string, value: string) => { store[key] = value; return Promise.resolve(); }),
+      removeItem: jest.fn((key: string) => { delete store[key]; return Promise.resolve(); }),
+      clear: jest.fn(() => { Object.keys(store).forEach((k) => { delete store[k]; }); return Promise.resolve(); }),
+    },
+  };
+});
+
+import {
+  getReminderEnabled,
+  setReminderEnabled,
+  getReminderTime,
+  setReminderTime,
+  getReminderSentDate,
+  setReminderSentDate,
+} from '../../utils/reminderStorage';
+
+beforeEach(async () => {
+  const AsyncStorage = require('@react-native-async-storage/async-storage').default;
+  await AsyncStorage.clear();
+  jest.clearAllMocks();
+});
+
+describe('reminderStorage', () => {
+  describe('reminderEnabled', () => {
+    it('returns false when nothing stored', async () => {
+      expect(await getReminderEnabled()).toBe(false);
+    });
+
+    it('persists true', async () => {
+      await setReminderEnabled(true);
+      expect(await getReminderEnabled()).toBe(true);
+    });
+
+    it('persists false after true', async () => {
+      await setReminderEnabled(true);
+      await setReminderEnabled(false);
+      expect(await getReminderEnabled()).toBe(false);
+    });
+  });
+
+  describe('reminderTime', () => {
+    it('returns null when nothing stored', async () => {
+      expect(await getReminderTime()).toBeNull();
+    });
+
+    it('persists hour and minute', async () => {
+      await setReminderTime(11, 30);
+      expect(await getReminderTime()).toEqual({ hour: 11, minute: 30 });
+    });
+
+    it('overwrites previous time', async () => {
+      await setReminderTime(11, 30);
+      await setReminderTime(12, 0);
+      expect(await getReminderTime()).toEqual({ hour: 12, minute: 0 });
+    });
+  });
+
+  describe('reminderSentDate', () => {
+    it('returns null when nothing stored', async () => {
+      expect(await getReminderSentDate()).toBeNull();
+    });
+
+    it('persists a date string', async () => {
+      await setReminderSentDate('2026-02-25');
+      expect(await getReminderSentDate()).toBe('2026-02-25');
+    });
+  });
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cd src/app && npx jest src-rn/__tests__/utils/reminderStorage.test.ts --no-coverage`
+Expected: FAIL — module not found
+
+**Step 3: Write the implementation**
+
+Create `src/app/src-rn/utils/reminderStorage.ts`:
+
+```typescript
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const REMINDER_ENABLED_KEY = 'daily_reminder_enabled';
+const REMINDER_HOUR_KEY = 'daily_reminder_hour';
+const REMINDER_MINUTE_KEY = 'daily_reminder_minute';
+const REMINDER_SENT_DATE_KEY = 'daily_reminder_sent_date';
+
+export async function getReminderEnabled(): Promise<boolean> {
+  const value = await AsyncStorage.getItem(REMINDER_ENABLED_KEY);
+  return value === 'true';
+}
+
+export async function setReminderEnabled(enabled: boolean): Promise<void> {
+  await AsyncStorage.setItem(REMINDER_ENABLED_KEY, String(enabled));
+}
+
+export async function getReminderTime(): Promise<{ hour: number; minute: number } | null> {
+  const hour = await AsyncStorage.getItem(REMINDER_HOUR_KEY);
+  const minute = await AsyncStorage.getItem(REMINDER_MINUTE_KEY);
+  if (hour === null || minute === null) return null;
+  return { hour: Number(hour), minute: Number(minute) };
+}
+
+export async function setReminderTime(hour: number, minute: number): Promise<void> {
+  await AsyncStorage.setItem(REMINDER_HOUR_KEY, String(hour));
+  await AsyncStorage.setItem(REMINDER_MINUTE_KEY, String(minute));
+}
+
+export async function getReminderSentDate(): Promise<string | null> {
+  return AsyncStorage.getItem(REMINDER_SENT_DATE_KEY);
+}
+
+export async function setReminderSentDate(dateKey: string): Promise<void> {
+  await AsyncStorage.setItem(REMINDER_SENT_DATE_KEY, dateKey);
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cd src/app && npx jest src-rn/__tests__/utils/reminderStorage.test.ts --no-coverage`
+Expected: 6 tests PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/app/src-rn/utils/reminderStorage.ts src/app/src-rn/__tests__/utils/reminderStorage.test.ts
+git commit -m "feat(#31): add reminder storage module for daily order notifications"
+```
+
+---
+
+### Task 2: Daily Reminder Check Logic
+
+**Files:**
+- Create: `src/app/src-rn/utils/dailyReminderCheck.ts`
+- Test: `src/app/src-rn/__tests__/utils/dailyReminderCheck.test.ts`
+
+This is a pure function module (no side effects at import time) that reads reminder settings, checks the time window, filters today's orders, and fires the notification. Separated from `notificationTasks.ts` for testability.
+
+**Step 1: Write the failing tests**
+
+Create `src/app/src-rn/__tests__/utils/dailyReminderCheck.test.ts`:
+
+```typescript
+jest.mock('@react-native-async-storage/async-storage', () => {
+  const store: Record<string, string> = {};
+  return {
+    __esModule: true,
+    default: {
+      getItem: jest.fn((key: string) => Promise.resolve(store[key] ?? null)),
+      setItem: jest.fn((key: string, value: string) => { store[key] = value; return Promise.resolve(); }),
+      removeItem: jest.fn((key: string) => { delete store[key]; return Promise.resolve(); }),
+      clear: jest.fn(() => { Object.keys(store).forEach((k) => { delete store[k]; }); return Promise.resolve(); }),
+    },
+  };
+});
+
+jest.mock('expo-notifications', () => ({
+  scheduleNotificationAsync: jest.fn(),
+}));
+
+jest.mock('../../store/orderStore', () => {
+  let orders: any[] = [];
+  return {
+    useOrderStore: {
+      getState: () => ({ orders }),
+      __setOrders: (o: any[]) => { orders = o; },
+    },
+  };
+});
+
+jest.mock('../../utils/dateUtils', () => ({
+  viennaMinutes: jest.fn(),
+  viennaToday: jest.fn(),
+  isSameDay: jest.fn((a: Date, b: Date) =>
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  ),
+  localDateKey: jest.fn((d: Date) => {
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${y}-${m}-${day}`;
+  }),
+}));
+
+import * as Notifications from 'expo-notifications';
+import { useOrderStore } from '../../store/orderStore';
+import { viennaMinutes, viennaToday } from '../../utils/dateUtils';
+import { setReminderEnabled, setReminderTime, setReminderSentDate } from '../../utils/reminderStorage';
+import { checkDailyReminder } from '../../utils/dailyReminderCheck';
+
+const mockViennaMinutes = viennaMinutes as jest.Mock;
+const mockViennaToday = viennaToday as jest.Mock;
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+  const AsyncStorage = require('@react-native-async-storage/async-storage').default;
+  await AsyncStorage.clear();
+  (useOrderStore as any).__setOrders([]);
+  mockViennaToday.mockReturnValue(new Date(2026, 1, 25)); // Feb 25, 2026
+});
+
+describe('checkDailyReminder', () => {
+  it('does nothing when reminder is disabled', async () => {
+    await setReminderEnabled(false);
+    await setReminderTime(11, 0);
+    mockViennaMinutes.mockReturnValue(11 * 60);
+
+    await checkDailyReminder();
+
+    expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when no time is configured', async () => {
+    await setReminderEnabled(true);
+    mockViennaMinutes.mockReturnValue(11 * 60);
+
+    await checkDailyReminder();
+
+    expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when outside the ±15 min time window', async () => {
+    await setReminderEnabled(true);
+    await setReminderTime(11, 0);
+    mockViennaMinutes.mockReturnValue(9 * 60); // 9:00, way before 11:00
+
+    (useOrderStore as any).__setOrders([
+      { positionId: '1', eatingCycleId: 'e1', date: new Date(2026, 1, 25), title: 'MENÜ I', subtitle: 'Schnitzel', approved: true },
+    ]);
+
+    await checkDailyReminder();
+
+    expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when no orders for today', async () => {
+    await setReminderEnabled(true);
+    await setReminderTime(11, 0);
+    mockViennaMinutes.mockReturnValue(11 * 60);
+
+    (useOrderStore as any).__setOrders([
+      { positionId: '1', eatingCycleId: 'e1', date: new Date(2026, 1, 26), title: 'MENÜ I', subtitle: 'Schnitzel', approved: true },
+    ]);
+
+    await checkDailyReminder();
+
+    expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when already sent today', async () => {
+    await setReminderEnabled(true);
+    await setReminderTime(11, 0);
+    await setReminderSentDate('2026-02-25');
+    mockViennaMinutes.mockReturnValue(11 * 60);
+
+    (useOrderStore as any).__setOrders([
+      { positionId: '1', eatingCycleId: 'e1', date: new Date(2026, 1, 25), title: 'MENÜ I', subtitle: 'Schnitzel', approved: true },
+    ]);
+
+    await checkDailyReminder();
+
+    expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
+  });
+
+  it('sends notification with single order', async () => {
+    await setReminderEnabled(true);
+    await setReminderTime(11, 0);
+    mockViennaMinutes.mockReturnValue(11 * 60);
+
+    (useOrderStore as any).__setOrders([
+      { positionId: '1', eatingCycleId: 'e1', date: new Date(2026, 1, 25), title: 'MENÜ II', subtitle: 'Wiener Schnitzel', approved: true },
+    ]);
+
+    await checkDailyReminder();
+
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
+      content: {
+        title: 'Deine Bestellung heute',
+        body: 'MENÜ II — Wiener Schnitzel',
+        sound: 'default',
+        data: { screen: '/(tabs)/orders' },
+      },
+      trigger: null,
+    });
+  });
+
+  it('sends notification with multiple orders', async () => {
+    await setReminderEnabled(true);
+    await setReminderTime(11, 0);
+    mockViennaMinutes.mockReturnValue(11 * 60 + 5); // 11:05, within window
+
+    (useOrderStore as any).__setOrders([
+      { positionId: '1', eatingCycleId: 'e1', date: new Date(2026, 1, 25), title: 'MENÜ II', subtitle: 'Wiener Schnitzel', approved: true },
+      { positionId: '2', eatingCycleId: 'e2', date: new Date(2026, 1, 25), title: 'SUPPE & SALAT', subtitle: 'Tomatensuppe', approved: true },
+    ]);
+
+    await checkDailyReminder();
+
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
+      content: {
+        title: 'Deine Bestellung heute',
+        body: 'MENÜ II — Wiener Schnitzel\nSUPPE & SALAT — Tomatensuppe',
+        sound: 'default',
+        data: { screen: '/(tabs)/orders' },
+      },
+      trigger: null,
+    });
+  });
+
+  it('marks sent date after firing notification', async () => {
+    await setReminderEnabled(true);
+    await setReminderTime(11, 0);
+    mockViennaMinutes.mockReturnValue(11 * 60);
+
+    (useOrderStore as any).__setOrders([
+      { positionId: '1', eatingCycleId: 'e1', date: new Date(2026, 1, 25), title: 'MENÜ I', subtitle: 'Test', approved: true },
+    ]);
+
+    await checkDailyReminder();
+    // Second call should not send again
+    await checkDailyReminder();
+
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends again on a new day', async () => {
+    await setReminderEnabled(true);
+    await setReminderTime(11, 0);
+    await setReminderSentDate('2026-02-24'); // yesterday
+    mockViennaMinutes.mockReturnValue(11 * 60);
+
+    (useOrderStore as any).__setOrders([
+      { positionId: '1', eatingCycleId: 'e1', date: new Date(2026, 1, 25), title: 'MENÜ I', subtitle: 'Test', approved: true },
+    ]);
+
+    await checkDailyReminder();
+
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires at boundary of ±15 min window', async () => {
+    await setReminderEnabled(true);
+    await setReminderTime(11, 0);
+    mockViennaMinutes.mockReturnValue(11 * 60 + 15); // exactly +15 min
+
+    (useOrderStore as any).__setOrders([
+      { positionId: '1', eatingCycleId: 'e1', date: new Date(2026, 1, 25), title: 'MENÜ I', subtitle: 'Test', approved: true },
+    ]);
+
+    await checkDailyReminder();
+
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire just outside ±15 min window', async () => {
+    await setReminderEnabled(true);
+    await setReminderTime(11, 0);
+    mockViennaMinutes.mockReturnValue(11 * 60 + 16); // +16 min, outside
+
+    (useOrderStore as any).__setOrders([
+      { positionId: '1', eatingCycleId: 'e1', date: new Date(2026, 1, 25), title: 'MENÜ I', subtitle: 'Test', approved: true },
+    ]);
+
+    await checkDailyReminder();
+
+    expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
+  });
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cd src/app && npx jest src-rn/__tests__/utils/dailyReminderCheck.test.ts --no-coverage`
+Expected: FAIL — module not found
+
+**Step 3: Write the implementation**
+
+Create `src/app/src-rn/utils/dailyReminderCheck.ts`:
+
+```typescript
+import * as Notifications from 'expo-notifications';
+import { useOrderStore } from '../store/orderStore';
+import { viennaMinutes, viennaToday, isSameDay, localDateKey } from './dateUtils';
+import {
+  getReminderEnabled,
+  getReminderTime,
+  getReminderSentDate,
+  setReminderSentDate,
+} from './reminderStorage';
+
+/**
+ * Check if a daily order reminder notification should fire.
+ * Called from BACKGROUND_ORDER_SYNC_TASK.
+ *
+ * Guards:
+ * 1. Reminder must be enabled
+ * 2. Time must be configured
+ * 3. Current Vienna time must be within ±15 min of configured time
+ * 4. There must be orders for today
+ * 5. Notification must not have been sent today already
+ */
+export async function checkDailyReminder(): Promise<void> {
+  const enabled = await getReminderEnabled();
+  if (!enabled) return;
+
+  const time = await getReminderTime();
+  if (!time) return;
+
+  const targetMinutes = time.hour * 60 + time.minute;
+  const currentMinutes = viennaMinutes();
+  if (Math.abs(currentMinutes - targetMinutes) > 15) return;
+
+  const today = viennaToday();
+  const todayKey = localDateKey(today);
+
+  const sentDate = await getReminderSentDate();
+  if (sentDate === todayKey) return;
+
+  const orders = useOrderStore.getState().orders;
+  const todayOrders = orders.filter((o) => isSameDay(o.date, today));
+  if (todayOrders.length === 0) return;
+
+  const body = todayOrders
+    .map((o) => (o.subtitle ? `${o.title} — ${o.subtitle}` : o.title))
+    .join('\n');
+
+  await Notifications.scheduleNotificationAsync({
+    content: {
+      title: 'Deine Bestellung heute',
+      body,
+      sound: 'default',
+      data: { screen: '/(tabs)/orders' },
+    },
+    trigger: null,
+  });
+
+  await setReminderSentDate(todayKey);
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cd src/app && npx jest src-rn/__tests__/utils/dailyReminderCheck.test.ts --no-coverage`
+Expected: 10 tests PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/app/src-rn/utils/dailyReminderCheck.ts src/app/src-rn/__tests__/utils/dailyReminderCheck.test.ts
+git commit -m "feat(#31): add daily reminder check logic with time window and dedup"
+```
+
+---
+
+### Task 3: Integrate into Background Task
+
+**Files:**
+- Modify: `src/app/src-rn/utils/notificationTasks.ts` (the `BACKGROUND_ORDER_SYNC_TASK` handler)
+
+**Step 1: Modify the background task to call `checkDailyReminder`**
+
+In `src/app/src-rn/utils/notificationTasks.ts`, inside the `TaskManager.defineTask(BACKGROUND_ORDER_SYNC_TASK, ...)` callback, add the daily reminder check. The existing task already calls `loadCachedOrders()`, so order data is available.
+
+Add import at top (inside the `if (Platform.OS !== 'web')` block or at module level):
+
+```typescript
+import { checkDailyReminder } from './dailyReminderCheck';
+```
+
+Modify the `BACKGROUND_ORDER_SYNC_TASK` handler to add `await checkDailyReminder()` after `await checkAndNotify()`:
+
+```typescript
+  TaskManager.defineTask(BACKGROUND_ORDER_SYNC_TASK, async () => {
+    try {
+      // Load cached orders (no network calls to avoid concurrent scraping)
+      await useOrderStore.getState().loadCachedOrders();
+
+      // Location-based notification check (only if company location configured)
+      if (useLocationStore.getState().hasCompanyLocation()) {
+        await checkAndNotify();
+      }
+
+      // Daily order reminder check
+      await checkDailyReminder();
+
+      return BackgroundTask.BackgroundTaskResult.Success;
+    } catch {
+      return BackgroundTask.BackgroundTaskResult.Failed;
+    }
+  });
+```
+
+Note: The guard `if (!useLocationStore.getState().hasCompanyLocation())` that previously caused an early return is moved to only wrap `checkAndNotify()`. The task should always run `checkDailyReminder()` regardless of whether a company location is configured.
+
+**Step 2: Ensure the background task also registers when reminder is enabled**
+
+Currently in `_layout.tsx`, the background sync is only registered when `hasCompanyLocation`. We need it to also register when the daily reminder is enabled. This will be handled in Task 5 (Settings UI), which calls `registerBackgroundSync()` when enabling the reminder.
+
+No changes to `_layout.tsx` needed here — the `enableNotifications()` call already registers the background sync, and we'll add a separate registration path from the settings toggle.
+
+**Step 3: Run all existing tests to verify no regressions**
+
+Run: `cd src/app && npx jest --no-coverage`
+Expected: All tests PASS
+
+**Step 4: Commit**
+
+```bash
+git add src/app/src-rn/utils/notificationTasks.ts
+git commit -m "feat(#31): integrate daily reminder check into background sync task"
+```
+
+---
+
+### Task 4: Register Background Sync for Reminder
+
+**Files:**
+- Modify: `src/app/app/_layout.tsx`
+
+The background sync task (`BACKGROUND_ORDER_SYNC_TASK`) currently only registers when a company location is set. It must also register when the daily reminder is enabled, so the task runs even without location-based notifications.
+
+**Step 1: Add reminder-aware registration to `_layout.tsx`**
+
+In `_layout.tsx`, add an effect that checks reminder state and registers the background sync:
+
+```typescript
+import { getReminderEnabled } from '../src-rn/utils/reminderStorage';
+```
+
+Add after the existing `useEffect` that calls `enableNotifications()`:
+
+```typescript
+  // Register background sync when daily reminder is enabled (even without company location)
+  useEffect(() => {
+    if (!isNative()) return;
+    (async () => {
+      const reminderEnabled = await getReminderEnabled();
+      if (reminderEnabled) {
+        await registerBackgroundSync();
+      }
+    })();
+  }, []);
+```
+
+Import `registerBackgroundSync` from `notificationService` (it may already be imported via `enableNotifications`; if not, add it to the import).
+
+**Step 2: Run all tests**
+
+Run: `cd src/app && npx jest --no-coverage`
+Expected: All tests PASS
+
+**Step 3: Commit**
+
+```bash
+git add src/app/app/_layout.tsx
+git commit -m "feat(#31): register background sync when daily reminder is enabled"
+```
+
+---
+
+### Task 5: Settings UI — Benachrichtigungen Section
+
+**Files:**
+- Modify: `src/app/app/(tabs)/settings.tsx`
+
+Restructure the settings screen: rename the location notification section and add the daily reminder toggle + time picker above it, all under a unified "Benachrichtigungen" heading.
+
+**Step 1: Add state and handlers for daily reminder**
+
+Add imports:
+
+```typescript
+import {
+  getReminderEnabled,
+  setReminderEnabled,
+  getReminderTime,
+  setReminderTime,
+} from '../../src-rn/utils/reminderStorage';
+import { registerBackgroundSync } from '../../src-rn/utils/notificationService';
+```
+
+Add state variables inside the component:
+
+```typescript
+  // Daily reminder state (mobile only)
+  const [reminderEnabled, setReminderEnabledState] = useState(false);
+  const [reminderHour, setReminderHour] = useState(11);
+  const [reminderMinute, setReminderMinute] = useState(0);
+```
+
+Load saved reminder state in the existing `useEffect` that loads credentials (or a new one):
+
+```typescript
+  useEffect(() => {
+    if (!isNative()) return;
+    (async () => {
+      const enabled = await getReminderEnabled();
+      setReminderEnabledState(enabled);
+      const time = await getReminderTime();
+      if (time) {
+        setReminderHour(time.hour);
+        setReminderMinute(time.minute);
+      }
+    })();
+  }, []);
+```
+
+Add handlers:
+
+```typescript
+  const handleReminderToggle = async () => {
+    const newValue = !reminderEnabled;
+    if (newValue) {
+      const granted = await requestNotificationPermissions();
+      if (!granted) {
+        alert('Berechtigung fehlt', 'Benachrichtigungen werden für diese Funktion benötigt. Bitte in den Einstellungen aktivieren.');
+        return;
+      }
+      await setReminderTime(reminderHour, reminderMinute);
+      await registerBackgroundSync();
+    }
+    await setReminderEnabled(newValue);
+    setReminderEnabledState(newValue);
+  };
+
+  const handleReminderTimeChange = async (hour: number, minute: number) => {
+    setReminderHour(hour);
+    setReminderMinute(minute);
+    await setReminderTime(hour, minute);
+  };
+```
+
+**Step 2: Build time picker options**
+
+Generate 15-min increment time options:
+
+```typescript
+const TIME_OPTIONS: { hour: number; minute: number; label: string }[] = [];
+for (let h = 0; h < 24; h++) {
+  for (let m = 0; m < 60; m += 15) {
+    TIME_OPTIONS.push({
+      hour: h,
+      minute: m,
+      label: `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`,
+    });
+  }
+}
+```
+
+Place this outside the component (module-level constant).
+
+**Step 3: Replace `locationCard` with unified `notificationCard`**
+
+Replace the existing `locationCard` variable with a `notificationCard` that contains both sub-features. Use a `Switch` for the reminder toggle and a horizontal `ScrollView` or a picker for the time. For simplicity and cross-platform consistency, use a row of `Pressable` buttons showing the selected time with left/right arrows or a dropdown-style selector.
+
+Recommended approach — a simple `Pressable` that cycles through times, or a pair of Pressable for hour and minute. Simplest: show the current time as a tappable element that opens a scrollable list.
+
+For MVP, use a horizontal `ScrollView` of time chips (similar to the theme selector pattern already in the settings):
+
+```tsx
+  const notificationCard = isNative() ? (
+    <View style={isWideLayout ? styles.desktopCard : undefined}>
+      {!isWideLayout && <View style={styles.divider} />}
+      <Text style={styles.sectionTitle}>Benachrichtigungen</Text>
+
+      {/* Daily Reminder */}
+      <View style={styles.reminderRow}>
+        <View style={{ flex: 1 }}>
+          <Text style={styles.label}>Bestell-Erinnerung</Text>
+          <Text style={styles.reminderHint}>
+            Tägliche Erinnerung an deine Bestellung
+          </Text>
+        </View>
+        <Switch
+          value={reminderEnabled}
+          onValueChange={handleReminderToggle}
+          trackColor={{ false: colors.border, true: colors.primary }}
+        />
+      </View>
+
+      {reminderEnabled && (
+        <View style={styles.timePickerSection}>
+          <Text style={styles.label}>Uhrzeit</Text>
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            style={styles.timeScroll}
+            contentContainerStyle={styles.timeScrollContent}
+          >
+            {TIME_OPTIONS.map((opt) => {
+              const isSelected = opt.hour === reminderHour && opt.minute === reminderMinute;
+              return (
+                <Pressable
+                  key={opt.label}
+                  style={[styles.timeChip, isSelected && styles.timeChipActive]}
+                  onPress={() => handleReminderTimeChange(opt.hour, opt.minute)}
+                >
+                  <Text style={[styles.timeChipText, isSelected && styles.timeChipTextActive]}>
+                    {opt.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </ScrollView>
+        </View>
+      )}
+
+      <View style={styles.divider} />
+
+      {/* Location Notifications (existing) */}
+      <Text style={styles.label}>Standort-Benachrichtigungen</Text>
+      <Text style={styles.reminderHint}>
+        Erinnerung um 8:45 basierend auf deinem Standort
+      </Text>
+
+      {companyLocation ? (
+        <View>
+          <Text style={styles.sessionInfo}>
+            Firmenstandort gesetzt
+          </Text>
+          <Pressable style={styles.buttonDanger} onPress={handleRemoveLocation}>
+            <Text style={styles.buttonDangerText}>Standort entfernen</Text>
+          </Pressable>
+        </View>
+      ) : (
+        <Pressable
+          style={[styles.button, styles.buttonPrimary]}
+          onPress={handleSetLocation}
+          disabled={locationSaving}
+        >
+          <Text style={styles.buttonPrimaryText}>
+            {locationSaving ? 'Standort wird ermittelt...' : 'Aktuellen Standort als Firmenstandort setzen'}
+          </Text>
+        </Pressable>
+      )}
+    </View>
+  ) : null;
+```
+
+Add `Switch` to the React Native imports at the top of the file.
+
+**Step 4: Add styles**
+
+Add to `createStyles`:
+
+```typescript
+    reminderRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      marginBottom: isCompactDesktop ? 8 : 12,
+    },
+    reminderHint: {
+      fontSize: isCompactDesktop ? 11 : 12,
+      color: c.textTertiary,
+      marginTop: 2,
+    },
+    timePickerSection: {
+      marginBottom: isCompactDesktop ? 10 : 16,
+    },
+    timeScroll: {
+      marginTop: isCompactDesktop ? 4 : 8,
+    },
+    timeScrollContent: {
+      gap: isCompactDesktop ? 6 : 8,
+    },
+    timeChip: {
+      paddingHorizontal: isCompactDesktop ? 10 : 14,
+      paddingVertical: isCompactDesktop ? 6 : 10,
+      ...bannerSurface(c),
+    },
+    timeChipActive: {
+      backgroundColor: useFlatStyle ? c.primarySurface : c.glassPrimary,
+      borderColor: useFlatStyle ? c.primary : undefined,
+      borderBottomColor: c.primary,
+    },
+    timeChipText: {
+      fontSize: isCompactDesktop ? 12 : 14,
+      fontWeight: '600',
+      color: c.textSecondary,
+    },
+    timeChipTextActive: {
+      color: c.primary,
+    },
+```
+
+**Step 5: Replace `locationCard` references in the JSX**
+
+In both the `isWideLayout` and mobile render paths, replace `{locationCard}` with `{notificationCard}`.
+
+**Step 6: Run all tests**
+
+Run: `cd src/app && npx jest --no-coverage`
+Expected: All tests PASS
+
+**Step 7: Commit**
+
+```bash
+git add src/app/app/\(tabs\)/settings.tsx
+git commit -m "feat(#31): add daily reminder settings with time picker to Benachrichtigungen section"
+```
+
+---
+
+### Task 6: Run Full Test Suite and Verify
+
+**Step 1: Run all tests**
+
+Run: `cd src/app && npx jest --no-coverage`
+Expected: All tests PASS (existing + new)
+
+**Step 2: Verify new test count**
+
+The new tests add:
+- `reminderStorage.test.ts`: 6 tests
+- `dailyReminderCheck.test.ts`: 10 tests
+- Total new: 16 tests
+
+**Step 3: Commit if any fixes were needed**
+
+If any fixes were required, commit them:
+```bash
+git commit -m "fix(#31): address test issues"
+```

--- a/docs/plans/2026-02-25-daily-order-reminder.md
+++ b/docs/plans/2026-02-25-daily-order-reminder.md
@@ -12,7 +12,7 @@
 
 ---
 
-### Task 1: Reminder Storage Module
+## Task 1: Reminder Storage Module
 
 **Files:**
 - Create: `src/app/src-rn/utils/reminderStorage.ts`
@@ -112,8 +112,7 @@ Create `src/app/src-rn/utils/reminderStorage.ts`:
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const REMINDER_ENABLED_KEY = 'daily_reminder_enabled';
-const REMINDER_HOUR_KEY = 'daily_reminder_hour';
-const REMINDER_MINUTE_KEY = 'daily_reminder_minute';
+const REMINDER_TIME_KEY = 'daily_reminder_time';
 const REMINDER_SENT_DATE_KEY = 'daily_reminder_sent_date';
 
 export async function getReminderEnabled(): Promise<boolean> {
@@ -126,23 +125,34 @@ export async function setReminderEnabled(enabled: boolean): Promise<void> {
 }
 
 export async function getReminderTime(): Promise<{ hour: number; minute: number } | null> {
-  const hour = await AsyncStorage.getItem(REMINDER_HOUR_KEY);
-  const minute = await AsyncStorage.getItem(REMINDER_MINUTE_KEY);
-  if (hour === null || minute === null) return null;
-  return { hour: Number(hour), minute: Number(minute) };
+  const raw = await AsyncStorage.getItem(REMINDER_TIME_KEY);
+  if (raw === null) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    if (
+      parsed !== null &&
+      typeof parsed === 'object' &&
+      typeof parsed.hour === 'number' &&
+      typeof parsed.minute === 'number'
+    ) {
+      return parsed as { hour: number; minute: number };
+    }
+    return null;
+  } catch {
+    return null;
+  }
 }
 
 export async function setReminderTime(hour: number, minute: number): Promise<void> {
-  await AsyncStorage.setItem(REMINDER_HOUR_KEY, String(hour));
-  await AsyncStorage.setItem(REMINDER_MINUTE_KEY, String(minute));
+  await AsyncStorage.setItem(REMINDER_TIME_KEY, JSON.stringify({ hour, minute }));
 }
 
 export async function getReminderSentDate(): Promise<string | null> {
   return AsyncStorage.getItem(REMINDER_SENT_DATE_KEY);
 }
 
-export async function setReminderSentDate(dateKey: string): Promise<void> {
-  await AsyncStorage.setItem(REMINDER_SENT_DATE_KEY, dateKey);
+export async function setReminderSentDate(dateString: string): Promise<void> {
+  await AsyncStorage.setItem(REMINDER_SENT_DATE_KEY, dateString);
 }
 ```
 
@@ -160,7 +170,7 @@ git commit -m "feat(#31): add reminder storage module for daily order notificati
 
 ---
 
-### Task 2: Daily Reminder Check Logic
+## Task 2: Daily Reminder Check Logic
 
 **Files:**
 - Create: `src/app/src-rn/utils/dailyReminderCheck.ts`
@@ -486,7 +496,7 @@ git commit -m "feat(#31): add daily reminder check logic with time window and de
 
 ---
 
-### Task 3: Integrate into Background Task
+## Task 3: Integrate into Background Task
 
 **Files:**
 - Modify: `src/app/src-rn/utils/notificationTasks.ts` (the `BACKGROUND_ORDER_SYNC_TASK` handler)
@@ -546,7 +556,7 @@ git commit -m "feat(#31): integrate daily reminder check into background sync ta
 
 ---
 
-### Task 4: Register Background Sync for Reminder
+## Task 4: Register Background Sync for Reminder
 
 **Files:**
 - Modify: `src/app/app/_layout.tsx`
@@ -592,7 +602,7 @@ git commit -m "feat(#31): register background sync when daily reminder is enable
 
 ---
 
-### Task 5: Settings UI — Benachrichtigungen Section
+## Task 5: Settings UI — Benachrichtigungen Section
 
 **Files:**
 - Modify: `src/app/app/(tabs)/settings.tsx`
@@ -835,7 +845,7 @@ git commit -m "feat(#31): add daily reminder settings with time picker to Benach
 
 ---
 
-### Task 6: Run Full Test Suite and Verify
+## Task 6: Run Full Test Suite and Verify
 
 **Step 1: Run all tests**
 

--- a/src/app/app/(tabs)/settings.tsx
+++ b/src/app/app/(tabs)/settings.tsx
@@ -165,8 +165,7 @@ export default function SettingsScreen() {
     })();
   }, []);
 
-  const handleReminderToggle = async () => {
-    const newValue = !reminderEnabled;
+  const handleReminderToggle = async (newValue: boolean) => {
     if (newValue) {
       const granted = await requestNotificationPermissions();
       if (!granted) {

--- a/src/app/app/(tabs)/settings.tsx
+++ b/src/app/app/(tabs)/settings.tsx
@@ -5,6 +5,7 @@ import {
   Pressable,
   ScrollView,
   StyleSheet,
+  Switch,
   Text,
   TextInput,
   View,
@@ -22,7 +23,14 @@ import {
   getCurrentPosition,
   enableNotifications,
   disableNotifications,
+  registerBackgroundSync,
 } from '../../src-rn/utils/notificationService';
+import {
+  getReminderEnabled,
+  setReminderEnabled,
+  getReminderTime,
+  setReminderTime,
+} from '../../src-rn/utils/reminderStorage';
 import { useUpdateStore, applyUpdate } from '../../src-rn/utils/desktopUpdater';
 import { useTheme } from '../../src-rn/theme/useTheme';
 import { useDesktopLayout } from '../../src-rn/hooks/useDesktopLayout';
@@ -43,6 +51,17 @@ const THEME_OPTIONS: { value: ThemePreference; label: string }[] = [
   { value: 'light', label: 'Hell' },
   { value: 'dark', label: 'Dunkel' },
 ];
+
+const TIME_OPTIONS: { hour: number; minute: number; label: string }[] = [];
+for (let h = 0; h < 24; h++) {
+  for (let m = 0; m < 60; m += 15) {
+    TIME_OPTIONS.push({
+      hour: h,
+      minute: m,
+      label: `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`,
+    });
+  }
+}
 
 export default function SettingsScreen() {
   const { colors } = useTheme();
@@ -97,6 +116,11 @@ export default function SettingsScreen() {
   const clearCompanyLocation = useLocationStore((s) => s.clearCompanyLocation);
   const [locationSaving, setLocationSaving] = useState(false);
 
+  // Daily reminder state (mobile only)
+  const [reminderEnabled, setReminderEnabledState] = useState(false);
+  const [reminderHour, setReminderHour] = useState(11);
+  const [reminderMinute, setReminderMinute] = useState(0);
+
   const handleSetLocation = async () => {
     setLocationSaving(true);
     try {
@@ -125,6 +149,41 @@ export default function SettingsScreen() {
   const handleRemoveLocation = async () => {
     clearCompanyLocation();
     await disableNotifications();
+  };
+
+  // Load saved reminder state (mobile only)
+  useEffect(() => {
+    if (!isNative()) return;
+    (async () => {
+      const enabled = await getReminderEnabled();
+      setReminderEnabledState(enabled);
+      const time = await getReminderTime();
+      if (time) {
+        setReminderHour(time.hour);
+        setReminderMinute(time.minute);
+      }
+    })();
+  }, []);
+
+  const handleReminderToggle = async () => {
+    const newValue = !reminderEnabled;
+    if (newValue) {
+      const granted = await requestNotificationPermissions();
+      if (!granted) {
+        alert('Berechtigung fehlt', 'Benachrichtigungen werden für diese Funktion benötigt. Bitte in den Einstellungen aktivieren.');
+        return;
+      }
+      await setReminderTime(reminderHour, reminderMinute);
+      await registerBackgroundSync();
+    }
+    await setReminderEnabled(newValue);
+    setReminderEnabledState(newValue);
+  };
+
+  const handleReminderTimeChange = async (hour: number, minute: number) => {
+    setReminderHour(hour);
+    setReminderMinute(minute);
+    await setReminderTime(hour, minute);
   };
 
   // Load saved credentials on mount
@@ -400,11 +459,58 @@ export default function SettingsScreen() {
     </View>
   ) : null;
 
-  const locationCard = isNative() ? (
+  const notificationCard = isNative() ? (
     <View style={isWideLayout ? styles.desktopCard : undefined}>
       {!isWideLayout && <View style={styles.divider} />}
-      <Text style={styles.sectionTitle}>Standort-Benachrichtigungen</Text>
-      <Text style={styles.sectionSubtitle}>
+      <Text style={styles.sectionTitle}>Benachrichtigungen</Text>
+
+      {/* Daily Reminder */}
+      <View style={styles.reminderRow}>
+        <View style={{ flex: 1 }}>
+          <Text style={styles.label}>Bestell-Erinnerung</Text>
+          <Text style={styles.reminderHint}>
+            Tägliche Erinnerung an deine Bestellung
+          </Text>
+        </View>
+        <Switch
+          value={reminderEnabled}
+          onValueChange={handleReminderToggle}
+          trackColor={{ false: colors.border, true: colors.primary }}
+        />
+      </View>
+
+      {reminderEnabled && (
+        <View style={styles.timePickerSection}>
+          <Text style={styles.label}>Uhrzeit</Text>
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            style={styles.timeScroll}
+            contentContainerStyle={styles.timeScrollContent}
+          >
+            {TIME_OPTIONS.map((opt) => {
+              const isSelected = opt.hour === reminderHour && opt.minute === reminderMinute;
+              return (
+                <Pressable
+                  key={opt.label}
+                  style={[styles.timeChip, isSelected && styles.timeChipActive]}
+                  onPress={() => handleReminderTimeChange(opt.hour, opt.minute)}
+                >
+                  <Text style={[styles.timeChipText, isSelected && styles.timeChipTextActive]}>
+                    {opt.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </ScrollView>
+        </View>
+      )}
+
+      <View style={styles.divider} />
+
+      {/* Location Notifications (existing) */}
+      <Text style={styles.label}>Standort-Benachrichtigungen</Text>
+      <Text style={styles.reminderHint}>
         Erinnerung um 8:45 basierend auf deinem Standort
       </Text>
 
@@ -444,7 +550,7 @@ export default function SettingsScreen() {
             {appearanceCard}
             {updatesCard}
           </View>
-          {locationCard}
+          {notificationCard}
           {privacyCard}
         </>
       ) : (
@@ -452,7 +558,7 @@ export default function SettingsScreen() {
           {gourmetCard}
           {ventopayCard}
           {appearanceCard}
-          {locationCard}
+          {notificationCard}
           {updatesCard}
           {privacyCard}
         </>
@@ -594,6 +700,43 @@ const createStyles = (c: Colors) =>
       fontSize: isCompactDesktop ? 11 : 12,
       color: c.textTertiary,
       marginTop: isCompactDesktop ? 6 : 8,
+    },
+    reminderRow: {
+      flexDirection: 'row' as const,
+      alignItems: 'center' as const,
+      marginBottom: isCompactDesktop ? 8 : 12,
+    },
+    reminderHint: {
+      fontSize: isCompactDesktop ? 11 : 12,
+      color: c.textTertiary,
+      marginTop: 2,
+    },
+    timePickerSection: {
+      marginBottom: isCompactDesktop ? 10 : 16,
+    },
+    timeScroll: {
+      marginTop: isCompactDesktop ? 4 : 8,
+    },
+    timeScrollContent: {
+      gap: isCompactDesktop ? 6 : 8,
+    },
+    timeChip: {
+      paddingHorizontal: isCompactDesktop ? 10 : 14,
+      paddingVertical: isCompactDesktop ? 6 : 10,
+      ...bannerSurface(c),
+    },
+    timeChipActive: {
+      backgroundColor: useFlatStyle ? c.primarySurface : c.glassPrimary,
+      borderColor: useFlatStyle ? c.primary : undefined,
+      borderBottomColor: c.primary,
+    },
+    timeChipText: {
+      fontSize: isCompactDesktop ? 12 : 14,
+      fontWeight: '600' as const,
+      color: c.textSecondary,
+    },
+    timeChipTextActive: {
+      color: c.primary,
     },
     privacyRow: {
       flexDirection: 'row' as const,

--- a/src/app/app/_layout.tsx
+++ b/src/app/app/_layout.tsx
@@ -18,7 +18,9 @@ import {
   setupNotificationHandler,
   setupAndroidChannel,
   enableNotifications,
+  registerBackgroundSync,
 } from '../src-rn/utils/notificationService';
+import { getReminderEnabled } from '../src-rn/utils/reminderStorage';
 
 const backgroundMenuCheck = isNative()
   ? require('../src-rn/utils/backgroundMenuCheck')
@@ -65,6 +67,17 @@ function AppContent() {
     if (!isNative() || !hasCompanyLocation) return;
     enableNotifications();
   }, [hasCompanyLocation]);
+
+  // Register background sync when daily reminder is enabled (even without company location)
+  useEffect(() => {
+    if (!isNative()) return;
+    (async () => {
+      const reminderEnabled = await getReminderEnabled();
+      if (reminderEnabled) {
+        await registerBackgroundSync();
+      }
+    })();
+  }, []);
 
   return (
     <DialogProvider>

--- a/src/app/app/_layout.tsx
+++ b/src/app/app/_layout.tsx
@@ -71,10 +71,14 @@ function AppContent() {
   // Register background sync when daily reminder is enabled (even without company location)
   useEffect(() => {
     if (!isNative()) return;
-    (async () => {
-      const reminderEnabled = await getReminderEnabled();
-      if (reminderEnabled) {
-        await registerBackgroundSync();
+    void (async () => {
+      try {
+        const reminderEnabled = await getReminderEnabled();
+        if (reminderEnabled) {
+          await registerBackgroundSync();
+        }
+      } catch {
+        // Silent — background registration is best-effort
       }
     })();
   }, []);

--- a/src/app/src-rn/__tests__/utils/dailyReminderCheck.test.ts
+++ b/src/app/src-rn/__tests__/utils/dailyReminderCheck.test.ts
@@ -211,6 +211,28 @@ describe('checkDailyReminder', () => {
     expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledTimes(1);
   });
 
+  it('omits subtitle separator when subtitle is empty', async () => {
+    await setReminderEnabled(true);
+    await setReminderTime(11, 0);
+    mockViennaMinutes.mockReturnValue(11 * 60);
+
+    (useOrderStore as any).__setOrders([
+      { positionId: '1', eatingCycleId: 'e1', date: new Date(2026, 1, 25), title: 'MENÜ I', subtitle: '', approved: true },
+    ]);
+
+    await checkDailyReminder();
+
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
+      content: {
+        title: 'Deine Bestellung heute',
+        body: 'MENÜ I',
+        sound: 'default',
+        data: { screen: '/(tabs)/orders' },
+      },
+      trigger: null,
+    });
+  });
+
   it('does not fire just outside ±15 min window', async () => {
     await setReminderEnabled(true);
     await setReminderTime(11, 0);

--- a/src/app/src-rn/__tests__/utils/dailyReminderCheck.test.ts
+++ b/src/app/src-rn/__tests__/utils/dailyReminderCheck.test.ts
@@ -1,0 +1,227 @@
+jest.mock('@react-native-async-storage/async-storage', () => {
+  const store: Record<string, string> = {};
+  return {
+    __esModule: true,
+    default: {
+      getItem: jest.fn((key: string) => Promise.resolve(store[key] ?? null)),
+      setItem: jest.fn((key: string, value: string) => { store[key] = value; return Promise.resolve(); }),
+      removeItem: jest.fn((key: string) => { delete store[key]; return Promise.resolve(); }),
+      clear: jest.fn(() => { Object.keys(store).forEach((k) => { delete store[k]; }); return Promise.resolve(); }),
+    },
+  };
+});
+
+jest.mock('expo-notifications', () => ({
+  scheduleNotificationAsync: jest.fn(),
+}));
+
+jest.mock('../../store/orderStore', () => {
+  let orders: any[] = [];
+  return {
+    useOrderStore: {
+      getState: () => ({ orders }),
+      __setOrders: (o: any[]) => { orders = o; },
+    },
+  };
+});
+
+jest.mock('../../utils/dateUtils', () => ({
+  viennaMinutes: jest.fn(),
+  viennaToday: jest.fn(),
+  isSameDay: jest.fn((a: Date, b: Date) =>
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  ),
+  localDateKey: jest.fn((d: Date) => {
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${y}-${m}-${day}`;
+  }),
+}));
+
+import * as Notifications from 'expo-notifications';
+import { useOrderStore } from '../../store/orderStore';
+import { viennaMinutes, viennaToday } from '../../utils/dateUtils';
+import { setReminderEnabled, setReminderTime, setReminderSentDate } from '../../utils/reminderStorage';
+import { checkDailyReminder } from '../../utils/dailyReminderCheck';
+
+const mockViennaMinutes = viennaMinutes as jest.Mock;
+const mockViennaToday = viennaToday as jest.Mock;
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+  const AsyncStorage = require('@react-native-async-storage/async-storage').default;
+  await AsyncStorage.clear();
+  (useOrderStore as any).__setOrders([]);
+  mockViennaToday.mockReturnValue(new Date(2026, 1, 25)); // Feb 25, 2026
+});
+
+describe('checkDailyReminder', () => {
+  it('does nothing when reminder is disabled', async () => {
+    await setReminderEnabled(false);
+    await setReminderTime(11, 0);
+    mockViennaMinutes.mockReturnValue(11 * 60);
+
+    await checkDailyReminder();
+
+    expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when no time is configured', async () => {
+    await setReminderEnabled(true);
+    mockViennaMinutes.mockReturnValue(11 * 60);
+
+    await checkDailyReminder();
+
+    expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when outside the ±15 min time window', async () => {
+    await setReminderEnabled(true);
+    await setReminderTime(11, 0);
+    mockViennaMinutes.mockReturnValue(9 * 60); // 9:00, way before 11:00
+
+    (useOrderStore as any).__setOrders([
+      { positionId: '1', eatingCycleId: 'e1', date: new Date(2026, 1, 25), title: 'MENÜ I', subtitle: 'Schnitzel', approved: true },
+    ]);
+
+    await checkDailyReminder();
+
+    expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when no orders for today', async () => {
+    await setReminderEnabled(true);
+    await setReminderTime(11, 0);
+    mockViennaMinutes.mockReturnValue(11 * 60);
+
+    (useOrderStore as any).__setOrders([
+      { positionId: '1', eatingCycleId: 'e1', date: new Date(2026, 1, 26), title: 'MENÜ I', subtitle: 'Schnitzel', approved: true },
+    ]);
+
+    await checkDailyReminder();
+
+    expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when already sent today', async () => {
+    await setReminderEnabled(true);
+    await setReminderTime(11, 0);
+    await setReminderSentDate('2026-02-25');
+    mockViennaMinutes.mockReturnValue(11 * 60);
+
+    (useOrderStore as any).__setOrders([
+      { positionId: '1', eatingCycleId: 'e1', date: new Date(2026, 1, 25), title: 'MENÜ I', subtitle: 'Schnitzel', approved: true },
+    ]);
+
+    await checkDailyReminder();
+
+    expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
+  });
+
+  it('sends notification with single order', async () => {
+    await setReminderEnabled(true);
+    await setReminderTime(11, 0);
+    mockViennaMinutes.mockReturnValue(11 * 60);
+
+    (useOrderStore as any).__setOrders([
+      { positionId: '1', eatingCycleId: 'e1', date: new Date(2026, 1, 25), title: 'MENÜ II', subtitle: 'Wiener Schnitzel', approved: true },
+    ]);
+
+    await checkDailyReminder();
+
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
+      content: {
+        title: 'Deine Bestellung heute',
+        body: 'MENÜ II \u2014 Wiener Schnitzel',
+        sound: 'default',
+        data: { screen: '/(tabs)/orders' },
+      },
+      trigger: null,
+    });
+  });
+
+  it('sends notification with multiple orders', async () => {
+    await setReminderEnabled(true);
+    await setReminderTime(11, 0);
+    mockViennaMinutes.mockReturnValue(11 * 60 + 5); // 11:05, within window
+
+    (useOrderStore as any).__setOrders([
+      { positionId: '1', eatingCycleId: 'e1', date: new Date(2026, 1, 25), title: 'MENÜ II', subtitle: 'Wiener Schnitzel', approved: true },
+      { positionId: '2', eatingCycleId: 'e2', date: new Date(2026, 1, 25), title: 'SUPPE & SALAT', subtitle: 'Tomatensuppe', approved: true },
+    ]);
+
+    await checkDailyReminder();
+
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
+      content: {
+        title: 'Deine Bestellung heute',
+        body: 'MENÜ II \u2014 Wiener Schnitzel\nSUPPE & SALAT \u2014 Tomatensuppe',
+        sound: 'default',
+        data: { screen: '/(tabs)/orders' },
+      },
+      trigger: null,
+    });
+  });
+
+  it('marks sent date after firing notification', async () => {
+    await setReminderEnabled(true);
+    await setReminderTime(11, 0);
+    mockViennaMinutes.mockReturnValue(11 * 60);
+
+    (useOrderStore as any).__setOrders([
+      { positionId: '1', eatingCycleId: 'e1', date: new Date(2026, 1, 25), title: 'MENÜ I', subtitle: 'Test', approved: true },
+    ]);
+
+    await checkDailyReminder();
+    // Second call should not send again
+    await checkDailyReminder();
+
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends again on a new day', async () => {
+    await setReminderEnabled(true);
+    await setReminderTime(11, 0);
+    await setReminderSentDate('2026-02-24'); // yesterday
+    mockViennaMinutes.mockReturnValue(11 * 60);
+
+    (useOrderStore as any).__setOrders([
+      { positionId: '1', eatingCycleId: 'e1', date: new Date(2026, 1, 25), title: 'MENÜ I', subtitle: 'Test', approved: true },
+    ]);
+
+    await checkDailyReminder();
+
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires at boundary of ±15 min window', async () => {
+    await setReminderEnabled(true);
+    await setReminderTime(11, 0);
+    mockViennaMinutes.mockReturnValue(11 * 60 + 15); // exactly +15 min
+
+    (useOrderStore as any).__setOrders([
+      { positionId: '1', eatingCycleId: 'e1', date: new Date(2026, 1, 25), title: 'MENÜ I', subtitle: 'Test', approved: true },
+    ]);
+
+    await checkDailyReminder();
+
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire just outside ±15 min window', async () => {
+    await setReminderEnabled(true);
+    await setReminderTime(11, 0);
+    mockViennaMinutes.mockReturnValue(11 * 60 + 16); // +16 min, outside
+
+    (useOrderStore as any).__setOrders([
+      { positionId: '1', eatingCycleId: 'e1', date: new Date(2026, 1, 25), title: 'MENÜ I', subtitle: 'Test', approved: true },
+    ]);
+
+    await checkDailyReminder();
+
+    expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/src-rn/__tests__/utils/dailyReminderCheck.test.ts
+++ b/src/app/src-rn/__tests__/utils/dailyReminderCheck.test.ts
@@ -56,6 +56,7 @@ beforeEach(async () => {
   await AsyncStorage.clear();
   (useOrderStore as any).__setOrders([]);
   mockViennaToday.mockReturnValue(new Date(2026, 1, 25)); // Feb 25, 2026
+  mockViennaMinutes.mockReturnValue(0); // default: midnight, outside any reminder window
 });
 
 describe('checkDailyReminder', () => {

--- a/src/app/src-rn/__tests__/utils/dailyReminderCheck.test.ts
+++ b/src/app/src-rn/__tests__/utils/dailyReminderCheck.test.ts
@@ -234,6 +234,28 @@ describe('checkDailyReminder', () => {
     });
   });
 
+  it('omits subtitle separator when subtitle is undefined', async () => {
+    await setReminderEnabled(true);
+    await setReminderTime(11, 0);
+    mockViennaMinutes.mockReturnValue(11 * 60);
+
+    (useOrderStore as any).__setOrders([
+      { positionId: '1', eatingCycleId: 'e1', date: new Date(2026, 1, 25), title: 'MENÜ I', approved: true },
+    ]);
+
+    await checkDailyReminder();
+
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
+      content: {
+        title: 'Deine Bestellung heute',
+        body: 'MENÜ I',
+        sound: 'default',
+        data: { screen: '/(tabs)/orders' },
+      },
+      trigger: null,
+    });
+  });
+
   it('does not fire just outside ±15 min window', async () => {
     await setReminderEnabled(true);
     await setReminderTime(11, 0);

--- a/src/app/src-rn/__tests__/utils/reminderStorage.test.ts
+++ b/src/app/src-rn/__tests__/utils/reminderStorage.test.ts
@@ -1,0 +1,74 @@
+jest.mock('@react-native-async-storage/async-storage', () => {
+  const store: Record<string, string> = {};
+  return {
+    __esModule: true,
+    default: {
+      getItem: jest.fn((key: string) => Promise.resolve(store[key] ?? null)),
+      setItem: jest.fn((key: string, value: string) => { store[key] = value; return Promise.resolve(); }),
+      removeItem: jest.fn((key: string) => { delete store[key]; return Promise.resolve(); }),
+      clear: jest.fn(() => { Object.keys(store).forEach((k) => { delete store[k]; }); return Promise.resolve(); }),
+    },
+  };
+});
+
+import {
+  getReminderEnabled,
+  setReminderEnabled,
+  getReminderTime,
+  setReminderTime,
+  getReminderSentDate,
+  setReminderSentDate,
+} from '../../utils/reminderStorage';
+
+beforeEach(async () => {
+  const AsyncStorage = require('@react-native-async-storage/async-storage').default;
+  await AsyncStorage.clear();
+  jest.clearAllMocks();
+});
+
+describe('reminderStorage', () => {
+  describe('reminderEnabled', () => {
+    it('returns false when nothing stored', async () => {
+      expect(await getReminderEnabled()).toBe(false);
+    });
+
+    it('persists true', async () => {
+      await setReminderEnabled(true);
+      expect(await getReminderEnabled()).toBe(true);
+    });
+
+    it('persists false after true', async () => {
+      await setReminderEnabled(true);
+      await setReminderEnabled(false);
+      expect(await getReminderEnabled()).toBe(false);
+    });
+  });
+
+  describe('reminderTime', () => {
+    it('returns null when nothing stored', async () => {
+      expect(await getReminderTime()).toBeNull();
+    });
+
+    it('persists hour and minute', async () => {
+      await setReminderTime(11, 30);
+      expect(await getReminderTime()).toEqual({ hour: 11, minute: 30 });
+    });
+
+    it('overwrites previous time', async () => {
+      await setReminderTime(11, 30);
+      await setReminderTime(12, 0);
+      expect(await getReminderTime()).toEqual({ hour: 12, minute: 0 });
+    });
+  });
+
+  describe('reminderSentDate', () => {
+    it('returns null when nothing stored', async () => {
+      expect(await getReminderSentDate()).toBeNull();
+    });
+
+    it('persists a date string', async () => {
+      await setReminderSentDate('2026-02-25');
+      expect(await getReminderSentDate()).toBe('2026-02-25');
+    });
+  });
+});

--- a/src/app/src-rn/utils/backgroundMenuCheck.ts
+++ b/src/app/src-rn/utils/backgroundMenuCheck.ts
@@ -42,12 +42,6 @@ async function backgroundMenuCheckTask(): Promise<BackgroundTask.BackgroundTaskR
       return BackgroundTask.BackgroundTaskResult.Success;
     }
 
-    // Check if we already sent a notification for the current batch
-    const alreadySent = await getNotificationSent();
-    if (alreadySent) {
-      return BackgroundTask.BackgroundTaskResult.Success;
-    }
-
     // Login and fetch menus
     const api = new GourmetApi();
     await api.login(username, password);
@@ -58,7 +52,9 @@ async function backgroundMenuCheckTask(): Promise<BackgroundTask.BackgroundTaskR
     const knownMenus = await getKnownMenus();
     const hasNew = detectNewMenus(currentFingerprints, knownMenus);
 
-    if (hasNew) {
+    // Only notify if menus changed AND we haven't already sent for this batch
+    const alreadySent = await getNotificationSent();
+    if (hasNew && !alreadySent) {
       await Notifications.scheduleNotificationAsync({
         content: {
           title: 'Neue Menüs verfügbar',

--- a/src/app/src-rn/utils/dailyReminderCheck.ts
+++ b/src/app/src-rn/utils/dailyReminderCheck.ts
@@ -1,0 +1,58 @@
+import * as Notifications from 'expo-notifications';
+import { useOrderStore } from '../store/orderStore';
+import { viennaMinutes, viennaToday, isSameDay, localDateKey } from './dateUtils';
+import {
+  getReminderEnabled,
+  getReminderTime,
+  getReminderSentDate,
+  setReminderSentDate,
+} from './reminderStorage';
+
+/**
+ * Check if a daily order reminder notification should fire.
+ * Called from BACKGROUND_ORDER_SYNC_TASK.
+ *
+ * Guards:
+ * 1. Reminder must be enabled
+ * 2. Time must be configured
+ * 3. Current Vienna time must be within ±15 min of configured time
+ * 4. There must be orders for today
+ * 5. Notification must not have been sent today already
+ */
+export async function checkDailyReminder(): Promise<void> {
+  const enabled = await getReminderEnabled();
+  if (!enabled) return;
+
+  const time = await getReminderTime();
+  if (!time) return;
+
+  const targetMinutes = time.hour * 60 + time.minute;
+  const currentMinutes = viennaMinutes();
+  if (Math.abs(currentMinutes - targetMinutes) > 15) return;
+
+  const today = viennaToday();
+  const todayKey = localDateKey(today);
+
+  const sentDate = await getReminderSentDate();
+  if (sentDate === todayKey) return;
+
+  const orders = useOrderStore.getState().orders;
+  const todayOrders = orders.filter((o) => isSameDay(o.date, today));
+  if (todayOrders.length === 0) return;
+
+  const body = todayOrders
+    .map((o) => (o.subtitle ? `${o.title} \u2014 ${o.subtitle}` : o.title))
+    .join('\n');
+
+  await Notifications.scheduleNotificationAsync({
+    content: {
+      title: 'Deine Bestellung heute',
+      body,
+      sound: 'default',
+      data: { screen: '/(tabs)/orders' },
+    },
+    trigger: null,
+  });
+
+  await setReminderSentDate(todayKey);
+}

--- a/src/app/src-rn/utils/dailyReminderCheck.ts
+++ b/src/app/src-rn/utils/dailyReminderCheck.ts
@@ -44,6 +44,8 @@ export async function checkDailyReminder(): Promise<void> {
     .map((o) => (o.subtitle ? `${o.title} \u2014 ${o.subtitle}` : o.title))
     .join('\n');
 
+  await setReminderSentDate(todayKey);
+
   await Notifications.scheduleNotificationAsync({
     content: {
       title: 'Deine Bestellung heute',
@@ -53,6 +55,4 @@ export async function checkDailyReminder(): Promise<void> {
     },
     trigger: null,
   });
-
-  await setReminderSentDate(todayKey);
 }

--- a/src/app/src-rn/utils/dailyReminderCheck.ts
+++ b/src/app/src-rn/utils/dailyReminderCheck.ts
@@ -44,8 +44,6 @@ export async function checkDailyReminder(): Promise<void> {
     .map((o) => (o.subtitle ? `${o.title} \u2014 ${o.subtitle}` : o.title))
     .join('\n');
 
-  await setReminderSentDate(todayKey);
-
   await Notifications.scheduleNotificationAsync({
     content: {
       title: 'Deine Bestellung heute',
@@ -55,4 +53,6 @@ export async function checkDailyReminder(): Promise<void> {
     },
     trigger: null,
   });
+
+  await setReminderSentDate(todayKey);
 }

--- a/src/app/src-rn/utils/notificationTasks.ts
+++ b/src/app/src-rn/utils/notificationTasks.ts
@@ -44,11 +44,19 @@ if (Platform.OS !== 'web') {
 
       // Location-based notification check (only if company location configured)
       if (useLocationStore.getState().hasCompanyLocation()) {
-        await checkAndNotify();
+        try {
+          await checkAndNotify();
+        } catch {
+          // Silent — don't block other checks
+        }
       }
 
       // Daily order reminder check
-      await checkDailyReminder();
+      try {
+        await checkDailyReminder();
+      } catch {
+        // Silent — don't block other checks
+      }
 
       return BackgroundTask.BackgroundTaskResult.Success;
     } catch {

--- a/src/app/src-rn/utils/notificationTasks.ts
+++ b/src/app/src-rn/utils/notificationTasks.ts
@@ -5,6 +5,7 @@ import * as Notifications from 'expo-notifications';
 import { useLocationStore } from '../store/locationStore';
 import { useOrderStore } from '../store/orderStore';
 import { isSameDay, viennaMinutes, viennaToday } from './dateUtils';
+import { checkDailyReminder } from './dailyReminderCheck';
 import {
   GEOFENCE_TASK_NAME,
   BACKGROUND_ORDER_SYNC_TASK,
@@ -38,16 +39,16 @@ if (Platform.OS !== 'web') {
 
   TaskManager.defineTask(BACKGROUND_ORDER_SYNC_TASK, async () => {
     try {
-      // Only check if we have a company location configured
-      if (!useLocationStore.getState().hasCompanyLocation()) {
-        return BackgroundTask.BackgroundTaskResult.Success;
-      }
-
       // Load cached orders (no network calls to avoid concurrent scraping)
       await useOrderStore.getState().loadCachedOrders();
 
-      // Check if we should fire a notification
-      await checkAndNotify();
+      // Location-based notification check (only if company location configured)
+      if (useLocationStore.getState().hasCompanyLocation()) {
+        await checkAndNotify();
+      }
+
+      // Daily order reminder check
+      await checkDailyReminder();
 
       return BackgroundTask.BackgroundTaskResult.Success;
     } catch {

--- a/src/app/src-rn/utils/reminderStorage.ts
+++ b/src/app/src-rn/utils/reminderStorage.ts
@@ -1,8 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const REMINDER_ENABLED_KEY = 'daily_reminder_enabled';
-const REMINDER_HOUR_KEY = 'daily_reminder_hour';
-const REMINDER_MINUTE_KEY = 'daily_reminder_minute';
+const REMINDER_TIME_KEY = 'daily_reminder_time';
 const REMINDER_SENT_DATE_KEY = 'daily_reminder_sent_date';
 
 export async function getReminderEnabled(): Promise<boolean> {
@@ -15,21 +14,23 @@ export async function setReminderEnabled(enabled: boolean): Promise<void> {
 }
 
 export async function getReminderTime(): Promise<{ hour: number; minute: number } | null> {
-  const hour = await AsyncStorage.getItem(REMINDER_HOUR_KEY);
-  const minute = await AsyncStorage.getItem(REMINDER_MINUTE_KEY);
-  if (hour === null || minute === null) return null;
-  return { hour: Number(hour), minute: Number(minute) };
+  const raw = await AsyncStorage.getItem(REMINDER_TIME_KEY);
+  if (raw === null) return null;
+  try {
+    return JSON.parse(raw) as { hour: number; minute: number };
+  } catch {
+    return null;
+  }
 }
 
 export async function setReminderTime(hour: number, minute: number): Promise<void> {
-  await AsyncStorage.setItem(REMINDER_HOUR_KEY, String(hour));
-  await AsyncStorage.setItem(REMINDER_MINUTE_KEY, String(minute));
+  await AsyncStorage.setItem(REMINDER_TIME_KEY, JSON.stringify({ hour, minute }));
 }
 
 export async function getReminderSentDate(): Promise<string | null> {
   return AsyncStorage.getItem(REMINDER_SENT_DATE_KEY);
 }
 
-export async function setReminderSentDate(dateKey: string): Promise<void> {
-  await AsyncStorage.setItem(REMINDER_SENT_DATE_KEY, dateKey);
+export async function setReminderSentDate(dateString: string): Promise<void> {
+  await AsyncStorage.setItem(REMINDER_SENT_DATE_KEY, dateString);
 }

--- a/src/app/src-rn/utils/reminderStorage.ts
+++ b/src/app/src-rn/utils/reminderStorage.ts
@@ -1,0 +1,35 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const REMINDER_ENABLED_KEY = 'daily_reminder_enabled';
+const REMINDER_HOUR_KEY = 'daily_reminder_hour';
+const REMINDER_MINUTE_KEY = 'daily_reminder_minute';
+const REMINDER_SENT_DATE_KEY = 'daily_reminder_sent_date';
+
+export async function getReminderEnabled(): Promise<boolean> {
+  const value = await AsyncStorage.getItem(REMINDER_ENABLED_KEY);
+  return value === 'true';
+}
+
+export async function setReminderEnabled(enabled: boolean): Promise<void> {
+  await AsyncStorage.setItem(REMINDER_ENABLED_KEY, String(enabled));
+}
+
+export async function getReminderTime(): Promise<{ hour: number; minute: number } | null> {
+  const hour = await AsyncStorage.getItem(REMINDER_HOUR_KEY);
+  const minute = await AsyncStorage.getItem(REMINDER_MINUTE_KEY);
+  if (hour === null || minute === null) return null;
+  return { hour: Number(hour), minute: Number(minute) };
+}
+
+export async function setReminderTime(hour: number, minute: number): Promise<void> {
+  await AsyncStorage.setItem(REMINDER_HOUR_KEY, String(hour));
+  await AsyncStorage.setItem(REMINDER_MINUTE_KEY, String(minute));
+}
+
+export async function getReminderSentDate(): Promise<string | null> {
+  return AsyncStorage.getItem(REMINDER_SENT_DATE_KEY);
+}
+
+export async function setReminderSentDate(dateKey: string): Promise<void> {
+  await AsyncStorage.setItem(REMINDER_SENT_DATE_KEY, dateKey);
+}

--- a/src/app/src-rn/utils/reminderStorage.ts
+++ b/src/app/src-rn/utils/reminderStorage.ts
@@ -17,7 +17,16 @@ export async function getReminderTime(): Promise<{ hour: number; minute: number 
   const raw = await AsyncStorage.getItem(REMINDER_TIME_KEY);
   if (raw === null) return null;
   try {
-    return JSON.parse(raw) as { hour: number; minute: number };
+    const parsed = JSON.parse(raw);
+    if (
+      parsed !== null &&
+      typeof parsed === 'object' &&
+      typeof parsed.hour === 'number' &&
+      typeof parsed.minute === 'number'
+    ) {
+      return parsed as { hour: number; minute: number };
+    }
+    return null;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary

- Add daily local notification showing today's ordered meals at a user-configured time
- Piggybacks on existing `BACKGROUND_ORDER_SYNC_TASK` infrastructure (runs ~every 15 min, checks if within ±15 min of configured time)
- New "Benachrichtigungen" settings section groups the reminder toggle + horizontal time picker (15-min increments) with existing location-based notifications
- Storage layer (`reminderStorage.ts`) persists enabled state, time, and per-day dedup flag via AsyncStorage
- Native-only (iOS + Android), web stubs not needed (reuses existing no-op patterns)

**Note:** This PR is based on the `feature/issue-13-menu-notifications` branch (notification infrastructure). It should be merged after that branch lands on main.

Closes #31

## Test Plan

- [ ] 20 new tests (8 storage + 12 reminder logic) all pass
- [ ] Full suite: 315/315 pass, no regressions
- [ ] Enable reminder in Settings, pick a time, verify toggle and time chip persist after app restart
- [ ] With an order for today and time window matching, verify notification fires in background
- [ ] Verify no notification when: disabled, no orders today, already sent today, outside time window
- [ ] Verify location notifications still work independently under the unified section