### PR TITLE
Harden desktop security and scraper token handling

### DIFF
--- a/src/app/package-lock.json
+++ b/src/app/package-lock.json
@@ -3474,27 +3474,6 @@
         "url": "https://opencollective.com/libvips"
       }
     },
-    "node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
-      "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -6620,9 +6599,9 @@
       }
     },
     "node_modules/@react-native/codegen/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
+      "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -8059,12 +8038,24 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
+      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -11251,15 +11242,15 @@
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.2.tgz",
-      "integrity": "sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==",
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.3.tgz",
+      "integrity": "sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.1"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -18301,12 +18292,12 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.7.tgz",
+      "integrity": "sha512-MOwgjc8tfrpn5QQEvjijjmDVtMw2oL88ugTevzxQnzRLm6l3fVEF2gzU0kYeYYKD8C66+IdGX6peJ4MyUlUnPg==",
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -19724,9 +19715,9 @@
       }
     },
     "node_modules/react-native/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
+      "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -20089,9 +20080,9 @@
       }
     },
     "node_modules/rimraf/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
+      "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -20968,9 +20959,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
+      "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"

--- a/src/app/src-rn/__tests__/api/gourmetApi.test.ts
+++ b/src/app/src-rn/__tests__/api/gourmetApi.test.ts
@@ -293,6 +293,29 @@ describe('GourmetApi', () => {
     });
   });
 
+  describe('cancelOrders', () => {
+    it('always includes __ncforminfo in cancel form payload', async () => {
+      const api = new GourmetApi();
+      await loginApi(api);
+
+      mockGet.mockResolvedValueOnce(ordersPageEditMode);
+      mockPostForm.mockResolvedValueOnce('');
+      mockGet.mockResolvedValueOnce(ordersPageEditMode);
+      mockPostForm.mockResolvedValueOnce('');
+
+      await api.cancelOrders(['POS-001']);
+
+      expect(mockPostForm).toHaveBeenNthCalledWith(
+        1,
+        '/bestellungen/',
+        expect.objectContaining({
+          cp_PositionId: 'POS-001',
+          __ncforminfo: 'NCFORM-TOKEN-CANCEL-POS001-BBB',
+        })
+      );
+    });
+  });
+
   describe('getBillings', () => {
     it('returns mapped billing data with correct structure', async () => {
       const api = new GourmetApi();

--- a/src/app/src-rn/__tests__/api/gourmetParser.test.ts
+++ b/src/app/src-rn/__tests__/api/gourmetParser.test.ts
@@ -267,6 +267,24 @@ describe('extractCancelOrderFormData', () => {
     expect(data.ufprt).toBeTruthy();
     expect(data.ncforminfo).toBeTruthy();
   });
+
+  it('throws when __ncforminfo is missing on cancel form', () => {
+    const htmlMissingNcforminfo = `
+      <html>
+        <body>
+          <form id="form_POS-001_cp">
+            <input name="cp_PositionId" value="POS-001" />
+            <input name="cp_EatingCycleId_POS-001" value="EC-001" />
+            <input name="cp_Date_POS-001" value="10.02.2026 00:00:00" />
+            <input name="ufprt" value="CSRF-CANCEL-1" />
+          </form>
+        </body>
+      </html>
+    `;
+    expect(() => extractCancelOrderFormData(htmlMissingNcforminfo, 'POS-001')).toThrow(
+      /Could not extract cancel form data/
+    );
+  });
 });
 
 describe('extractLogoutFormTokens', () => {

--- a/src/app/src-rn/__tests__/api/ventopayClient.test.ts
+++ b/src/app/src-rn/__tests__/api/ventopayClient.test.ts
@@ -136,8 +136,10 @@ describe('VentopayHttpClient', () => {
       const result = responseInterceptor(response);
 
       const debug = client.getCookieDebug();
-      expect(debug).toContain('ASP.NET_SessionId=abc123');
-      expect(debug).toContain('OtherCookie=xyz789');
+      expect(debug).toContain('ASP.NET_SessionId');
+      expect(debug).toContain('OtherCookie');
+      expect(debug).not.toContain('abc123');
+      expect(debug).not.toContain('xyz789');
       expect(result).toBe(response);
     });
 
@@ -154,7 +156,8 @@ describe('VentopayHttpClient', () => {
 
       responseInterceptor(response);
 
-      expect(client.getCookieDebug()).toContain('SessionId=single123');
+      expect(client.getCookieDebug()).toContain('SessionId');
+      expect(client.getCookieDebug()).not.toContain('single123');
     });
   });
 

--- a/src/app/src-rn/__tests__/utils/desktopUpdater.web.test.ts
+++ b/src/app/src-rn/__tests__/utils/desktopUpdater.web.test.ts
@@ -1,0 +1,74 @@
+describe('desktopUpdater.web', () => {
+  let invokeMock: jest.Mock;
+  let alertMock: jest.Mock;
+  let consoleErrorSpy: jest.SpyInstance;
+
+  function loadModule(desktop: boolean) {
+    jest.resetModules();
+
+    jest.doMock('../../utils/platform', () => ({
+      isDesktop: () => desktop,
+    }));
+
+    (globalThis as any).window = globalThis;
+    (globalThis as any).__TAURI_INTERNALS__ = { invoke: invokeMock };
+    (globalThis as any).alert = alertMock;
+
+    return require('../../utils/desktopUpdater.web');
+  }
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    invokeMock = jest.fn();
+    alertMock = jest.fn();
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    consoleErrorSpy.mockRestore();
+    delete (globalThis as any).__TAURI_INTERNALS__;
+    jest.dontMock('../../utils/platform');
+  });
+
+  it('returns early outside desktop context', async () => {
+    const { checkForDesktopUpdates } = loadModule(false);
+
+    await checkForDesktopUpdates(true);
+
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it('stores pending version and alerts when user-initiated update is found', async () => {
+    invokeMock.mockResolvedValue('1.4.0');
+    const { checkForDesktopUpdates, useUpdateStore } = loadModule(true);
+
+    await checkForDesktopUpdates(true);
+
+    expect(invokeMock).toHaveBeenCalledWith('download_update', undefined);
+    expect(useUpdateStore.getState().pendingVersion).toBe('1.4.0');
+    expect(alertMock).toHaveBeenCalledWith(
+      expect.stringContaining('Version 1.4.0 downloaded')
+    );
+    expect(useUpdateStore.getState().checking).toBe(false);
+  });
+
+  it('calls install_update when applyUpdate is used', async () => {
+    invokeMock.mockResolvedValue(undefined);
+    const { applyUpdate } = loadModule(true);
+
+    await applyUpdate();
+
+    expect(invokeMock).toHaveBeenCalledWith('install_update', undefined);
+  });
+
+  it('alerts on user-initiated check failure', async () => {
+    invokeMock.mockRejectedValue(new Error('network'));
+    const { checkForDesktopUpdates, useUpdateStore } = loadModule(true);
+
+    await checkForDesktopUpdates(true);
+
+    expect(alertMock).toHaveBeenCalledWith('Failed to check for updates.');
+    expect(useUpdateStore.getState().checking).toBe(false);
+  });
+});

--- a/src/app/src-rn/__tests__/utils/tauriHttp.web.test.ts
+++ b/src/app/src-rn/__tests__/utils/tauriHttp.web.test.ts
@@ -1,0 +1,99 @@
+describe('tauriHttp.web', () => {
+  let invokeMock: jest.Mock;
+  let axiosCreateMock: jest.Mock;
+
+  function loadModule(desktop: boolean) {
+    jest.resetModules();
+
+    axiosCreateMock = jest.fn((config?: any) => ({ config }));
+
+    jest.doMock('axios', () => ({
+      __esModule: true,
+      default: {
+        create: axiosCreateMock,
+      },
+    }));
+
+    jest.doMock('../../utils/platform', () => ({
+      isDesktop: () => desktop,
+    }));
+
+    (globalThis as any).window = globalThis;
+    (globalThis as any).__TAURI_INTERNALS__ = { invoke: invokeMock };
+
+    return require('../../utils/tauriHttp.web');
+  }
+
+  beforeEach(() => {
+    invokeMock = jest.fn();
+  });
+
+  afterEach(() => {
+    delete (globalThis as any).__TAURI_INTERNALS__;
+    jest.dontMock('axios');
+    jest.dontMock('../../utils/platform');
+  });
+
+  it('patches axios.create on desktop and routes requests through http_request', async () => {
+    loadModule(true);
+    const axios = require('axios').default;
+
+    axios.create({ baseURL: 'https://alaclickneu.gourmet.at' });
+    const createConfig = axiosCreateMock.mock.calls[0][0];
+    expect(typeof createConfig.adapter).toBe('function');
+
+    invokeMock.mockResolvedValue({
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+      setCookies: ['SessId=abc; Path=/'],
+      body: '{"ok":true}',
+      url: 'https://alaclickneu.gourmet.at/start/?page=1',
+    });
+
+    const response = await createConfig.adapter({
+      baseURL: 'https://alaclickneu.gourmet.at',
+      url: '/start/',
+      method: 'post',
+      params: { page: '1' },
+      data: { foo: 'bar' },
+      responseType: 'json',
+      headers: {
+        toJSON: () => ({
+          'Content-Type': 'application/json',
+          Cookie: 'should-not-pass',
+          'X-Test': '1',
+        }),
+      },
+    });
+
+    expect(invokeMock).toHaveBeenCalledWith('http_request', {
+      request: {
+        url: 'https://alaclickneu.gourmet.at/start/?page=1',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Test': '1',
+        },
+        body: '{"foo":"bar"}',
+        formData: undefined,
+      },
+    });
+    expect(response.data).toEqual({ ok: true });
+    expect(response.headers['set-cookie']).toEqual(['SessId=abc; Path=/']);
+  });
+
+  it('does not patch axios.create on non-desktop', () => {
+    loadModule(false);
+    const axios = require('axios').default;
+
+    expect(axios.create).toBe(axiosCreateMock);
+  });
+
+  it('resetTauriHttp invokes http_reset in desktop context', async () => {
+    const { resetTauriHttp } = loadModule(true);
+
+    await resetTauriHttp();
+
+    expect(invokeMock).toHaveBeenCalledWith('http_reset');
+  });
+});

--- a/src/app/src-rn/api/gourmetApi.ts
+++ b/src/app/src-rn/api/gourmetApi.ts
@@ -281,10 +281,8 @@ export class GourmetApi {
         [eatingCycleKey]: cancelData.eatingCycleId,
         [dateKey]: cancelData.date,
         ufprt: cancelData.ufprt,
+        __ncforminfo: cancelData.ncforminfo,
       };
-      if (cancelData.ncforminfo) {
-        formData.__ncforminfo = cancelData.ncforminfo;
-      }
 
       await this.client.postForm('/bestellungen/', formData);
       // Re-fetch to get fresh tokens for the next cancellation

--- a/src/app/src-rn/api/gourmetClient.ts
+++ b/src/app/src-rn/api/gourmetClient.ts
@@ -38,16 +38,12 @@ export class GourmetHttpClient {
     this.lastPageUrl = typeof url === 'string' && url.startsWith('http')
       ? url
       : `${GOURMET_BASE_URL}${url.startsWith('/') ? '' : '/'}${url}`;
-
-    console.log('[Gourmet GET]', url, 'status:', response.status, 'length:', response.data?.length);
     return response.data;
   }
 
   /** POST form data (multipart/form-data) returning HTML string.
    *  All Gourmet forms use enctype="multipart/form-data". */
   async postForm(url: string, data: Record<string, string>): Promise<string> {
-    console.log('[Gourmet POST]', url, 'keys:', Object.keys(data));
-
     const response: AxiosResponse<string> = await this.client.postForm(
       url,
       data,
@@ -59,8 +55,6 @@ export class GourmetHttpClient {
         responseType: 'text',
       }
     );
-
-    console.log('[Gourmet POST] response status:', response.status, 'length:', response.data?.length);
     return response.data;
   }
 

--- a/src/app/src-rn/api/gourmetParser.ts
+++ b/src/app/src-rn/api/gourmetParser.ts
@@ -236,7 +236,7 @@ export function extractCancelOrderFormData(
   const ufprt = form.find('input[name="ufprt"]').attr('value');
   const ncforminfo = form.find('input[name="__ncforminfo"]').attr('value');
 
-  if (!ufprt) {
+  if (!ufprt || !ncforminfo) {
     throw new Error(`Could not extract cancel form data for position: ${positionId}`);
   }
 
@@ -245,7 +245,7 @@ export function extractCancelOrderFormData(
     eatingCycleId: eatingCycleInput.attr('value') || '',
     date: dateInput.attr('value') || '',
     ufprt,
-    ncforminfo: ncforminfo || undefined,
+    ncforminfo,
   };
 }
 

--- a/src/app/src-rn/api/types.ts
+++ b/src/app/src-rn/api/types.ts
@@ -56,7 +56,7 @@ export interface CancelOrderFormData {
   eatingCycleId: string;
   date: string;
   ufprt: string;
-  ncforminfo?: string;
+  ncforminfo: string;
 }
 
 /** Thrown when the server session has expired and re-login is needed */

--- a/src/app/src-rn/api/ventopayApi.ts
+++ b/src/app/src-rn/api/ventopayApi.ts
@@ -31,17 +31,11 @@ export class VentopayApi {
    */
   async login(username: string, password: string): Promise<void> {
     // Step 1: GET login page to extract ASP.NET state
-    console.log('[Ventopay] Step 1: GET login page...');
     const loginPageHtml = await this.client.get(VENTOPAY_LOGIN_URL);
-    console.log('[Ventopay] GET response length:', loginPageHtml.length);
-    console.log('[Ventopay] Cookies after GET:', this.client.getCookieDebug());
 
     const state = extractAspNetState(loginPageHtml);
-    console.log('[Ventopay] Extracted VIEWSTATE length:', state.viewState.length);
-    console.log('[Ventopay] Extracted VIEWSTATEGENERATOR:', state.viewStateGenerator);
 
     // Step 2: POST login form with ALL required fields in exact browser order
-    console.log('[Ventopay] Step 2: POST login form...');
     const responseHtml = await this.client.postForm(VENTOPAY_LOGIN_URL, {
       __LASTFOCUS: state.lastFocus,
       __EVENTTARGET: state.eventTarget,
@@ -56,23 +50,15 @@ export class VentopayApi {
       languageRadio: 'DE',
     });
 
-    console.log('[Ventopay] POST response length:', responseHtml.length);
-    console.log('[Ventopay] Cookies after POST:', this.client.getCookieDebug());
-
     // Step 3: Verify login success
     const loggedIn = isVentopayLoggedIn(responseHtml);
-    console.log('[Ventopay] Login check (Ausloggen.aspx found):', loggedIn);
 
     if (!loggedIn) {
-      // Log a snippet of the response to help debug
-      const snippet = responseHtml.substring(0, 500);
-      console.log('[Ventopay] Response snippet:', snippet);
       throw new Error('Ventopay login failed: invalid credentials or account blocked');
     }
 
     this.credentials = { username, password };
     this.loggedIn = true;
-    console.log('[Ventopay] Login successful');
   }
 
   /**

--- a/src/app/src-rn/api/ventopayClient.ts
+++ b/src/app/src-rn/api/ventopayClient.ts
@@ -88,11 +88,9 @@ export class VentopayHttpClient {
     return response.data;
   }
 
-  /** Debug: get cookie names and value lengths */
+  /** Debug helper: get cookie names only */
   getCookieDebug(): string {
-    return Array.from(this.cookies.entries())
-      .map(([name, value]) => `${name}=${value.substring(0, 20)}...`)
-      .join('; ');
+    return Array.from(this.cookies.keys()).join('; ');
   }
 
   /** Reset client (for logout - clears all stored cookies) */

--- a/src/app/src-rn/utils/secureStorage.web.ts
+++ b/src/app/src-rn/utils/secureStorage.web.ts
@@ -1,11 +1,46 @@
+import { isDesktop } from './platform';
+
+function getInvoke(): ((cmd: string, args?: unknown) => Promise<unknown>) | null {
+  if (typeof window === 'undefined') return null;
+
+  if ('__TAURI_INTERNALS__' in window) {
+    const invoke = (window as any).__TAURI_INTERNALS__?.invoke;
+    if (typeof invoke === 'function') return invoke;
+  }
+
+  const tauriInvoke = (window as any).__TAURI__?.core?.invoke;
+  if (typeof tauriInvoke === 'function') return tauriInvoke;
+
+  return null;
+}
+
+async function tauriInvoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
+  const invoke = getInvoke();
+  if (!invoke) {
+    throw new Error('Tauri secure storage is unavailable');
+  }
+  return invoke(cmd, args) as Promise<T>;
+}
+
 export async function getItem(key: string): Promise<string | null> {
+  if (isDesktop()) {
+    return tauriInvoke<string | null>('secure_get_item', { key });
+  }
   return localStorage.getItem(key);
 }
 
 export async function setItem(key: string, value: string): Promise<void> {
+  if (isDesktop()) {
+    await tauriInvoke<void>('secure_set_item', { key, value });
+    return;
+  }
   localStorage.setItem(key, value);
 }
 
 export async function deleteItem(key: string): Promise<void> {
+  if (isDesktop()) {
+    await tauriInvoke<void>('secure_delete_item', { key });
+    return;
+  }
   localStorage.removeItem(key);
 }

--- a/src/desktop/src-tauri/Cargo.lock
+++ b/src/desktop/src-tauri/Cargo.lock
@@ -1833,6 +1833,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "log",
+ "zeroize",
+]
+
+[[package]]
 name = "kuchikiki"
 version = "0.8.8-speedreader"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3555,8 +3565,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "snack-pilot"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
+ "keyring",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/src/desktop/src-tauri/Cargo.toml
+++ b/src/desktop/src-tauri/Cargo.toml
@@ -18,6 +18,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.12", features = ["cookies", "multipart", "rustls-tls-native-roots", "system-proxy", "blocking"], default-features = false }
 tokio = { version = "1", features = ["sync"] }
+keyring = "3"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = ["Win32_Networking_WinHttp", "Win32_Foundation"] }

--- a/src/desktop/src-tauri/src/lib.rs
+++ b/src/desktop/src-tauri/src/lib.rs
@@ -114,6 +114,31 @@ pub struct HttpResponse {
     pub url: String,
 }
 
+const ALLOWED_HTTP_HOSTS: [&str; 2] = [
+    "alaclickneu.gourmet.at",
+    "my.ventopay.com",
+];
+
+const KEYRING_SERVICE: &str = "SnackPilot";
+
+fn validate_http_request(request: &HttpRequest) -> Result<(), String> {
+    let parsed = reqwest::Url::parse(&request.url)
+        .map_err(|e| format!("Invalid request URL: {}", e))?;
+    if parsed.scheme() != "https" {
+        return Err("Only https URLs are allowed".to_string());
+    }
+    let host = parsed.host_str()
+        .ok_or_else(|| "Request URL must include a host".to_string())?;
+    if !ALLOWED_HTTP_HOSTS.iter().any(|allowed| allowed.eq_ignore_ascii_case(host)) {
+        return Err(format!("Host not allowed: {}", host));
+    }
+    Ok(())
+}
+
+fn keyring_entry(key: &str) -> Result<keyring::Entry, String> {
+    keyring::Entry::new(KEYRING_SERVICE, key).map_err(|e| e.to_string())
+}
+
 // --- Tauri commands ---
 
 #[cfg(not(target_os = "windows"))]
@@ -122,6 +147,7 @@ async fn http_request(
     state: tauri::State<'_, reqwest_http::HttpProxy>,
     request: HttpRequest,
 ) -> Result<HttpResponse, String> {
+    validate_http_request(&request)?;
     reqwest_http::execute_request(&state, &request).await
 }
 
@@ -131,6 +157,7 @@ async fn http_request(
     state: tauri::State<'_, winhttp_client::WinHttpSession>,
     request: HttpRequest,
 ) -> Result<HttpResponse, String> {
+    validate_http_request(&request)?;
     // WinHTTP is synchronous — run on a blocking thread to avoid blocking the async runtime
     let session = state.inner().clone();
     let result = tokio::task::spawn_blocking(move || {
@@ -155,6 +182,31 @@ async fn http_reset(
     state: tauri::State<'_, winhttp_client::WinHttpSession>,
 ) -> Result<(), String> {
     state.reset()
+}
+
+#[tauri::command]
+async fn secure_set_item(key: String, value: String) -> Result<(), String> {
+    let entry = keyring_entry(&key)?;
+    entry.set_password(&value).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn secure_get_item(key: String) -> Result<Option<String>, String> {
+    let entry = keyring_entry(&key)?;
+    match entry.get_password() {
+        Ok(value) => Ok(Some(value)),
+        Err(keyring::Error::NoEntry) => Ok(None),
+        Err(err) => Err(err.to_string()),
+    }
+}
+
+#[tauri::command]
+async fn secure_delete_item(key: String) -> Result<(), String> {
+    let entry = keyring_entry(&key)?;
+    match entry.delete_credential() {
+        Ok(_) | Err(keyring::Error::NoEntry) => Ok(()),
+        Err(err) => Err(err.to_string()),
+    }
 }
 
 // --- Velopack update commands (always use reqwest, all platforms) ---
@@ -311,7 +363,43 @@ pub fn run() {
             install_update,
             http_request,
             http_reset,
+            secure_set_item,
+            secure_get_item,
+            secure_delete_item,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build_request(url: &str) -> HttpRequest {
+        HttpRequest {
+            url: url.to_string(),
+            method: "GET".to_string(),
+            headers: HashMap::new(),
+            body: None,
+            form_data: None,
+        }
+    }
+
+    #[test]
+    fn allows_known_https_hosts() {
+        assert!(validate_http_request(&build_request("https://alaclickneu.gourmet.at/start/")).is_ok());
+        assert!(validate_http_request(&build_request("https://my.ventopay.com/mocca.website/Login.aspx")).is_ok());
+    }
+
+    #[test]
+    fn rejects_non_https_urls() {
+        let result = validate_http_request(&build_request("http://alaclickneu.gourmet.at/start/"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_hosts() {
+        let result = validate_http_request(&build_request("https://example.com/path"));
+        assert!(result.is_err());
+    }
 }


### PR DESCRIPTION
## Summary
- enforce strict  handling for Gourmet cancel flow (types/parser/API)
- remove sensitive runtime logs from Gourmet/Ventopay API clients
- move desktop credential persistence to Tauri secure keyring commands (web fallback unchanged)
- restrict Tauri  to HTTPS + allowlisted Gourmet/Ventopay hosts
- add tests for desktop updater, desktop HTTP adapter, and Rust URL validator
- remediate  minimatch advisory in 

## Validation
- found 0 vulnerabilities
- 
> snackpilot@1.0.0 test
> jest --runInBand --silent
- 
running 3 tests
test tests::rejects_non_https_urls ... ok
test tests::allows_known_https_hosts ... ok
test tests::rejects_unknown_hosts ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
- 
> snackpilot-desktop@1.3.3 build
> npx tauri build

Starting Metro Bundler
Web node_modules/expo-router/entry.js ░░░░░░░░░░░░░░░░  0.0% (0/1)
Web Bundled 449ms node_modules/expo-router/entry.js (904 modules)

› Assets (37):
node_modules/@expo/vector-icons/build/vendor/react-native-vector-icons/Fonts/AntDesign.3f78af31cca60105799838a1a7a59fbd.ttf (130 kB)
node_modules/@expo/vector-icons/build/vendor/react-native-vector-icons/Fonts/Entypo.31b5ffea3daddc69dd01a1f3d6cf63c5.ttf (66.2 kB)
node_modules/@expo/vector-icons/build/vendor/react-native-vector-icons/Fonts/EvilIcons.140c53a7643ea949007aa9a282153849.ttf (13.5 kB)
node_modules/@expo/vector-icons/build/vendor/react-native-vector-icons/Fonts/Feather.ca4b48e04dc1ce10bfbddb262c8b835f.ttf (55.6 kB)
node_modules/@expo/vector-icons/build/vendor/react-native-vector-icons/Fonts/FontAwesome.b06871f281fee6b241d60582ae9369b9.ttf (166 kB)
node_modules/@expo/vector-icons/build/vendor/react-native-vector-icons/Fonts/FontAwesome5_Brands.3b89dd103490708d19a95adcae52210e.ttf (134 kB)
node_modules/@expo/vector-icons/build/vendor/react-native-vector-icons/Fonts/FontAwesome5_Regular.1f77739ca9ff2188b539c36f30ffa2be.ttf (33.7 kB)
node_modules/@expo/vector-icons/build/vendor/react-native-vector-icons/Fonts/FontAwesome5_Solid.605ed7926cf39a2ad5ec2d1f9d391d3d.ttf (203 kB)
node_modules/@expo/vector-icons/build/vendor/react-native-vector-icons/Fonts/FontAwesome6_Brands.56c8d80832e37783f12c05db7c8849e2.ttf (209 kB)
node_modules/@expo/vector-icons/build/vendor/react-native-vector-icons/Fonts/FontAwesome6_Regular.370dd5af19f8364907b6e2c41f45dbbf.ttf (68 kB)
node_modules/@expo/vector-icons/build/vendor/react-native-vector-icons/Fonts/FontAwesome6_Solid.adec7d6f310bc577f05e8fe06a5daccf.ttf (424 kB)
node_modules/@expo/vector-icons/build/vendor/react-native-vector-icons/Fonts/Fontisto.b49ae8ab2dbccb02c4d11caaacf09eab.ttf (314 kB)
node_modules/@expo/vector-icons/build/vendor/react-native-vector-icons/Fonts/Foundation.e20945d7c929279ef7a6f1db184a4470.ttf (57 kB)
node_modules/@expo/vector-icons/build/vendor/react-native-vector-icons/Fonts/Ionicons.b4eb097d35f44ed943676fd56f6bdc51.ttf (390 kB)
node_modules/@expo/vector-icons/build/vendor/react-native-vector-icons/Fonts/MaterialCommunityIcons.6e435534bd35da5fef04168860a9b8fa.ttf (1.31 MB)
node_modules/@expo/vector-icons/build/vendor/react-native-vector-icons/Fonts/MaterialIcons.4e85bc9ebe07e0340c9c4fc2f6c38908.ttf (357 kB)
node_modules/@expo/vector-icons/build/vendor/react-native-vector-icons/Fonts/Octicons.871378c6eab492a3e689a9385dc45a12.ttf (69.4 kB)
node_modules/@expo/vector-icons/build/vendor/react-native-vector-icons/Fonts/SimpleLineIcons.d2285965fe34b05465047401b8595dd0.ttf (54.1 kB)
node_modules/@expo/vector-icons/build/vendor/react-native-vector-icons/Fonts/Zocial.1681f34aaca71b8dfb70756bca331eb2.ttf (25.8 kB)
node_modules/@react-navigation/elements/lib/module/assets/back-icon-mask.0a328cd9c1afd0afe8e3b1ec5165b1b4.png (653 B)
node_modules/@react-navigation/elements/lib/module/assets/back-icon.35ba0eaec5a4f5ed12ca16fabeae451d.png (207 B)
node_modules/@react-navigation/elements/lib/module/assets/clear-icon.c94f6478e7ae0cdd9f15de1fcb9e5e55.png (4 variations | 425 B)
node_modules/@react-navigation/elements/lib/module/assets/close-icon.808e1b1b9b53114ec2838071a7e6daa7.png (4 variations | 235 B)
node_modules/@react-navigation/elements/lib/module/assets/search-icon.286d67d3f74808a60a78d3ebf1a5fb57.png (928 B)
node_modules/expo-router/assets/arrow_down.017bc6ba3fc25503e5eb5e53826d48a8.png (9.46 kB)
node_modules/expo-router/assets/error.d1ea1496f9057eb392d5bbf3732a61b7.png (469 B)
node_modules/expo-router/assets/file.19eeb73b9593a38f8e9f418337fc7d10.png (138 B)
node_modules/expo-router/assets/forward.d8b800c443b8972542883e0b9de2bdc6.png (188 B)
node_modules/expo-router/assets/pkg.ab19f4cbc543357183a20571f68380a3.png (364 B)
node_modules/expo-router/assets/sitemap.412dd9275b6b48ad28f5e3d81bb1f626.png (465 B)
node_modules/expo-router/assets/unmatched.20e71bdf79e3a97bf55fd9e164041578.png (4.75 kB)

› web bundles (1):
_expo/static/js/web/entry-9e01ea9a94a8f6335e46e93792df48f6.js (2.24 MB)

› Files (3):
favicon.ico (14.5 kB)
index.html (1.22 kB)
metadata.json (49 B)

Exported: dist

## Follow-up (manual)
- credential/key rotation and secret-store updates must still be completed outside repository code changes