### PR TITLE
refactor: extract settings into sub-pages

### DIFF
--- a/src/app/app/(tabs)/settings.tsx
+++ b/src/app/app/(tabs)/settings.tsx
@@ -1,67 +1,36 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import {
-  KeyboardAvoidingView,
-  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
-  Switch,
   Text,
-  TextInput,
   View,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import { router } from 'expo-router';
 import { useFlatStyle, isCompactDesktop, isNative } from '../../src-rn/utils/platform';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useAuthStore } from '../../src-rn/store/authStore';
 import { useVentopayAuthStore } from '../../src-rn/store/ventopayAuthStore';
 import { isDesktop } from '../../src-rn/utils/platform';
-import { useLocationStore } from '../../src-rn/store/locationStore';
-import {
-  requestLocationPermissions,
-  requestNotificationPermissions,
-  getCurrentPosition,
-  enableNotifications,
-  disableNotifications,
-  registerBackgroundSync,
-} from '../../src-rn/utils/notificationService';
-import {
-  getReminderEnabled,
-  setReminderEnabled,
-  getReminderTime,
-  setReminderTime,
-} from '../../src-rn/utils/reminderStorage';
 import { useUpdateStore, applyUpdate } from '../../src-rn/utils/desktopUpdater';
 import { useTheme } from '../../src-rn/theme/useTheme';
 import { useDesktopLayout } from '../../src-rn/hooks/useDesktopLayout';
 import { useDialog } from '../../src-rn/components/DialogProvider';
-import { useThemeStore, ThemePreference } from '../../src-rn/store/themeStore';
+import { useThemeStore } from '../../src-rn/store/themeStore';
 import { useAnalyticsId } from '../../src-rn/hooks/useAnalyticsId';
-import { Colors, ACCENT_COLORS, AccentColorId } from '../../src-rn/theme/colors';
+import { Colors } from '../../src-rn/theme/colors';
 import {
-  inputField,
   buttonPrimary,
-  buttonDanger,
   bannerSurface,
   cardSurface,
 } from '../../src-rn/theme/platformStyles';
 
-const THEME_OPTIONS: { value: ThemePreference; label: string }[] = [
-  { value: 'system', label: 'System' },
-  { value: 'light', label: 'Hell' },
-  { value: 'dark', label: 'Dunkel' },
-];
-
-const TIME_OPTIONS: { hour: number; minute: number; label: string }[] = [];
-for (let h = 0; h < 24; h++) {
-  for (let m = 0; m < 60; m += 15) {
-    TIME_OPTIONS.push({
-      hour: h,
-      minute: m,
-      label: `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`,
-    });
-  }
-}
+const THEME_LABELS: Record<string, string> = {
+  system: 'System',
+  light: 'Hell',
+  dark: 'Dunkel',
+};
 
 export default function SettingsScreen() {
   const { colors } = useTheme();
@@ -71,348 +40,95 @@ export default function SettingsScreen() {
   const styles = useMemo(() => createStyles(colors), [colors]);
 
   const themePreference = useThemeStore((s) => s.preference);
-  const setThemePreference = useThemeStore((s) => s.setPreference);
-  const accentColor = useThemeStore((s) => s.accentColor);
-  const setAccentColor = useThemeStore((s) => s.setAccentColor);
 
-  // Gourmet auth
-  const {
-    status: gourmetStatus,
-    userInfo,
-    login: gourmetLogin,
-    logout: gourmetLogout,
-    saveCredentials: gourmetSaveCredentials,
-    getSavedCredentials: gourmetGetSavedCredentials,
-  } = useAuthStore();
+  const gourmetStatus = useAuthStore((s) => s.status);
+  const gourmetUsername = useAuthStore((s) => s.userInfo?.username);
+  const ventopayStatus = useVentopayAuthStore((s) => s.status);
 
-  // Ventopay auth
-  const {
-    status: ventopayStatus,
-    login: ventopayLogin,
-    logout: ventopayLogout,
-    saveCredentials: ventopaySaveCredentials,
-    getSavedCredentials: ventopayGetSavedCredentials,
-  } = useVentopayAuthStore();
-
-  // Gourmet form state
-  const [gUsername, setGUsername] = useState('');
-  const [gPassword, setGPassword] = useState('');
-  const [gSaving, setGSaving] = useState(false);
-
-  // Ventopay form state
-  const [vUsername, setVUsername] = useState('');
-  const [vPassword, setVPassword] = useState('');
-  const [vSaving, setVSaving] = useState(false);
-
-  // Analytics
   const analyticsId = useAnalyticsId();
-
-  // Desktop update state
   const pendingVersion = useUpdateStore((s) => s.pendingVersion);
-
-  // Location notifications (mobile only)
-  const companyLocation = useLocationStore((s) => s.companyLocation);
-  const setCompanyLocation = useLocationStore((s) => s.setCompanyLocation);
-  const clearCompanyLocation = useLocationStore((s) => s.clearCompanyLocation);
-  const [locationSaving, setLocationSaving] = useState(false);
-
-  // Daily reminder state (mobile only)
-  const [reminderEnabled, setReminderEnabledState] = useState(false);
-  const [reminderHour, setReminderHour] = useState(11);
-  const [reminderMinute, setReminderMinute] = useState(0);
-
-  const handleSetLocation = async () => {
-    setLocationSaving(true);
-    try {
-      const locGranted = await requestLocationPermissions();
-      if (!locGranted) {
-        alert('Berechtigung fehlt', 'Standortzugriff (immer) wird für diese Funktion benötigt. Bitte in den Einstellungen aktivieren.');
-        setLocationSaving(false);
-        return;
-      }
-      const notifGranted = await requestNotificationPermissions();
-      if (!notifGranted) {
-        alert('Berechtigung fehlt', 'Benachrichtigungen werden für diese Funktion benötigt. Bitte in den Einstellungen aktivieren.');
-        setLocationSaving(false);
-        return;
-      }
-      const position = await getCurrentPosition();
-      setCompanyLocation(position.latitude, position.longitude);
-      await enableNotifications();
-      alert('Gespeichert', 'Firmenstandort gesetzt. Du wirst um 8:45 benachrichtigt, wenn du im Büro bist und nicht bestellt hast.');
-    } catch {
-      alert('Fehler', 'Standort konnte nicht ermittelt werden.');
-    }
-    setLocationSaving(false);
-  };
-
-  const handleRemoveLocation = async () => {
-    clearCompanyLocation();
-    await disableNotifications();
-  };
-
-  // Load saved reminder state (mobile only)
-  useEffect(() => {
-    if (!isNative()) return;
-    (async () => {
-      const enabled = await getReminderEnabled();
-      setReminderEnabledState(enabled);
-      const time = await getReminderTime();
-      if (time) {
-        setReminderHour(time.hour);
-        setReminderMinute(time.minute);
-      }
-    })();
-  }, []);
-
-  const handleReminderToggle = async (newValue: boolean) => {
-    if (newValue) {
-      const granted = await requestNotificationPermissions();
-      if (!granted) {
-        alert('Berechtigung fehlt', 'Benachrichtigungen werden für diese Funktion benötigt. Bitte in den Einstellungen aktivieren.');
-        return;
-      }
-      await setReminderTime(reminderHour, reminderMinute);
-      await registerBackgroundSync();
-    }
-    await setReminderEnabled(newValue);
-    setReminderEnabledState(newValue);
-  };
-
-  const handleReminderTimeChange = async (hour: number, minute: number) => {
-    setReminderHour(hour);
-    setReminderMinute(minute);
-    await setReminderTime(hour, minute);
-  };
-
-  // Load saved credentials on mount
-  useEffect(() => {
-    (async () => {
-      const gCreds = await gourmetGetSavedCredentials();
-      if (gCreds) {
-        setGUsername(gCreds.username);
-        setGPassword(gCreds.password);
-      }
-      const vCreds = await ventopayGetSavedCredentials();
-      if (vCreds) {
-        setVUsername(vCreds.username);
-        setVPassword(vCreds.password);
-      }
-    })();
-  }, [gourmetGetSavedCredentials, ventopayGetSavedCredentials]);
-
-  // Gourmet handlers
-  const handleGourmetSave = async () => {
-    if (!gUsername || !gPassword) {
-      alert('Fehler', 'Bitte Benutzername und Passwort eingeben');
-      return;
-    }
-    setGSaving(true);
-    await gourmetSaveCredentials(gUsername, gPassword);
-    const success = await gourmetLogin(gUsername, gPassword);
-    setGSaving(false);
-    if (success) {
-      alert('Gespeichert', 'Kantine-Zugangsdaten sicher gespeichert');
-    } else {
-      const error = useAuthStore.getState().error;
-      alert('Login fehlgeschlagen', error || 'Anmeldung nicht möglich. Bitte Zugangsdaten prüfen.');
-    }
-  };
-
-  const handleGourmetLogout = async () => {
-    await gourmetLogout();
-  };
-
-  // Ventopay handlers
-  const handleVentopaySave = async () => {
-    if (!vUsername || !vPassword) {
-      alert('Fehler', 'Bitte Benutzername und Passwort eingeben');
-      return;
-    }
-    setVSaving(true);
-    await ventopaySaveCredentials(vUsername, vPassword);
-    const success = await ventopayLogin(vUsername, vPassword);
-    setVSaving(false);
-    if (success) {
-      alert('Gespeichert', 'Automaten-Zugangsdaten sicher gespeichert');
-    } else {
-      const error = useVentopayAuthStore.getState().error;
-      alert('Login fehlgeschlagen', error || 'Anmeldung nicht möglich. Bitte Zugangsdaten prüfen.');
-    }
-  };
-
-  const handleVentopayLogout = async () => {
-    await ventopayLogout();
-  };
 
   const gourmetCard = (
     <View style={isWideLayout ? styles.desktopCard : undefined}>
-      <Text style={styles.sectionTitle}>Kantine-Zugangsdaten</Text>
-
-      <View style={styles.inputGroup}>
-        <Text style={styles.label}>Benutzername</Text>
-        <TextInput
-          style={styles.input}
-          value={gUsername}
-          onChangeText={setGUsername}
-          placeholder="Benutzername eingeben"
-          placeholderTextColor={colors.textTertiary}
-          autoCapitalize="none"
-          autoCorrect={false}
-        />
-      </View>
-
-      <View style={styles.inputGroup}>
-        <Text style={styles.label}>Passwort</Text>
-        <TextInput
-          style={styles.input}
-          value={gPassword}
-          onChangeText={setGPassword}
-          placeholder="Passwort eingeben"
-          placeholderTextColor={colors.textTertiary}
-          secureTextEntry
-          autoCapitalize="none"
-          autoCorrect={false}
-        />
-      </View>
-
-      <Pressable
-        style={[styles.button, styles.buttonPrimary]}
-        onPress={handleGourmetSave}
-        disabled={gSaving}
-      >
-        <Text style={styles.buttonPrimaryText}>
-          {gSaving ? 'Speichern...' : 'Speichern'}
-        </Text>
-      </Pressable>
-
-      {gourmetStatus === 'authenticated' && (
-        <View style={styles.sessionSection}>
-          <Text style={styles.sessionInfo}>
-            Angemeldet als: {userInfo?.username}
+      <Pressable style={styles.navRow} onPress={() => router.push('/kantine-login')}>
+        <View style={{ flex: 1 }}>
+          <Text style={styles.sectionTitle}>Kantine-Zugangsdaten</Text>
+          <Text style={styles.navHint}>
+            {gourmetStatus === 'authenticated'
+              ? `Angemeldet als ${gourmetUsername}`
+              : 'Nicht angemeldet'}
           </Text>
-          <Pressable style={styles.buttonDanger} onPress={handleGourmetLogout}>
-            <Text style={styles.buttonDangerText}>Abmelden</Text>
-          </Pressable>
         </View>
-      )}
+        <Ionicons name="chevron-forward" size={20} color={colors.textTertiary} />
+      </Pressable>
     </View>
   );
 
   const ventopayCard = (
     <View style={isWideLayout ? styles.desktopCard : undefined}>
       {!isWideLayout && <View style={styles.divider} />}
-      <Text style={styles.sectionTitle}>Automaten-Zugangsdaten</Text>
-      <Text style={styles.sectionSubtitle}>Für Automaten und Kassenabrechnungen</Text>
-
-      <View style={styles.inputGroup}>
-        <Text style={styles.label}>Benutzername</Text>
-        <TextInput
-          style={styles.input}
-          value={vUsername}
-          onChangeText={setVUsername}
-          placeholder="Benutzername eingeben"
-          placeholderTextColor={colors.textTertiary}
-          autoCapitalize="none"
-          autoCorrect={false}
-        />
-      </View>
-
-      <View style={styles.inputGroup}>
-        <Text style={styles.label}>Passwort</Text>
-        <TextInput
-          style={styles.input}
-          value={vPassword}
-          onChangeText={setVPassword}
-          placeholder="Passwort eingeben"
-          placeholderTextColor={colors.textTertiary}
-          secureTextEntry
-          autoCapitalize="none"
-          autoCorrect={false}
-        />
-      </View>
-
-      <Pressable
-        style={[styles.button, styles.buttonPrimary]}
-        onPress={handleVentopaySave}
-        disabled={vSaving}
-      >
-        <Text style={styles.buttonPrimaryText}>
-          {vSaving ? 'Speichern...' : 'Speichern'}
-        </Text>
-      </Pressable>
-
-      {ventopayStatus === 'authenticated' && (
-        <View style={styles.sessionSection}>
-          <Text style={styles.sessionInfo}>Automaten-Sitzung aktiv</Text>
-          <Pressable style={styles.buttonDanger} onPress={handleVentopayLogout}>
-            <Text style={styles.buttonDangerText}>Abmelden</Text>
-          </Pressable>
+      <Pressable style={styles.navRow} onPress={() => router.push('/automaten-login')}>
+        <View style={{ flex: 1 }}>
+          <Text style={styles.sectionTitle}>Automaten-Zugangsdaten</Text>
+          <Text style={styles.navHint}>
+            {ventopayStatus === 'authenticated'
+              ? 'Sitzung aktiv'
+              : 'Nicht angemeldet'}
+          </Text>
         </View>
-      )}
+        <Ionicons name="chevron-forward" size={20} color={colors.textTertiary} />
+      </Pressable>
     </View>
   );
-
-  const ACCENT_OPTIONS = Object.entries(ACCENT_COLORS) as [AccentColorId, typeof ACCENT_COLORS[AccentColorId]][];
 
   const appearanceCard = (
-    <View style={isWideLayout ? styles.desktopCard : styles.appearanceSection}>
+    <View style={isWideLayout ? styles.desktopCard : undefined}>
       {!isWideLayout && <View style={styles.divider} />}
-      <Text style={styles.sectionTitle}>Darstellung</Text>
-      <View style={styles.themeRow}>
-        {THEME_OPTIONS.map((opt) => (
-          <Pressable
-            key={opt.value}
-            style={[
-              styles.themeOption,
-              themePreference === opt.value && styles.themeOptionActive,
-            ]}
-            onPress={() => setThemePreference(opt.value)}
-          >
-            <Text
-              style={[
-                styles.themeOptionText,
-                themePreference === opt.value && styles.themeOptionTextActive,
-              ]}
-            >
-              {opt.label}
-            </Text>
-          </Pressable>
-        ))}
-      </View>
-
-      <Text style={styles.accentLabel}>Akzentfarbe</Text>
-      <View style={styles.accentRow}>
-        {ACCENT_OPTIONS.map(([id, config]) => (
-          <Pressable
-            key={id}
-            style={styles.accentOption}
-            onPress={() => setAccentColor(id)}
-          >
-            <View
-              style={[
-                styles.accentCircle,
-                { backgroundColor: config.light.primary },
-                accentColor === id && { borderColor: config.light.primary, borderWidth: 3 },
-              ]}
-            >
-              {accentColor === id && (
-                <Ionicons name="checkmark" size={isCompactDesktop ? 16 : 20} color="#fff" />
-              )}
-            </View>
-            <Text
-              style={[
-                styles.accentOptionText,
-                accentColor === id && { color: colors.primary },
-              ]}
-            >
-              {config.label}
-            </Text>
-          </Pressable>
-        ))}
-      </View>
+      <Pressable style={styles.navRow} onPress={() => router.push('/appearance')}>
+        <View style={{ flex: 1 }}>
+          <Text style={styles.sectionTitle}>Darstellung</Text>
+          <Text style={styles.navHint}>
+            {THEME_LABELS[themePreference] || themePreference}
+          </Text>
+        </View>
+        <Ionicons name="chevron-forward" size={20} color={colors.textTertiary} />
+      </Pressable>
     </View>
   );
+
+  const notificationCard = isNative() ? (
+    <View style={isWideLayout ? styles.desktopCard : undefined}>
+      {!isWideLayout && <View style={styles.divider} />}
+      <Pressable style={styles.navRow} onPress={() => router.push('/notifications')}>
+        <View style={{ flex: 1 }}>
+          <Text style={styles.sectionTitle}>Benachrichtigungen</Text>
+          <Text style={styles.navHint}>Erinnerungen und Standort-Benachrichtigungen</Text>
+        </View>
+        <Ionicons name="chevron-forward" size={20} color={colors.textTertiary} />
+      </Pressable>
+    </View>
+  ) : null;
+
+  const updatesCard = isDesktop() && pendingVersion ? (
+    <View style={isWideLayout ? styles.desktopCard : undefined}>
+      {!isWideLayout && <View style={styles.divider} />}
+      <Text style={styles.sectionTitle}>Updates</Text>
+      <Text style={styles.updateAvailableText}>
+        Version {pendingVersion} ist bereit zur Installation.
+      </Text>
+      <View style={styles.buttonRow}>
+        <Pressable
+          style={[styles.button, styles.buttonPrimary]}
+          onPress={applyUpdate}
+        >
+          <Text style={styles.buttonPrimaryText}>Jetzt aktualisieren</Text>
+        </Pressable>
+      </View>
+      <Text style={styles.updateHintText}>
+        Das Update wird auch beim nächsten Neustart automatisch angewendet.
+      </Text>
+    </View>
+  ) : null;
 
   const privacyCard = (
     <View style={styles.privacyRow}>
@@ -437,108 +153,8 @@ export default function SettingsScreen() {
     </View>
   );
 
-  const updatesCard = isDesktop() && pendingVersion ? (
-    <View style={isWideLayout ? styles.desktopCard : undefined}>
-      {!isWideLayout && <View style={styles.divider} />}
-      <Text style={styles.sectionTitle}>Updates</Text>
-      <Text style={styles.updateAvailableText}>
-        Version {pendingVersion} ist bereit zur Installation.
-      </Text>
-      <View style={styles.buttonRow}>
-        <Pressable
-          style={[styles.button, styles.buttonPrimary]}
-          onPress={applyUpdate}
-        >
-          <Text style={styles.buttonPrimaryText}>Jetzt aktualisieren</Text>
-        </Pressable>
-      </View>
-      <Text style={styles.updateHintText}>
-        Das Update wird auch beim nächsten Neustart automatisch angewendet.
-      </Text>
-    </View>
-  ) : null;
-
-  const notificationCard = isNative() ? (
-    <View style={isWideLayout ? styles.desktopCard : undefined}>
-      {!isWideLayout && <View style={styles.divider} />}
-      <Text style={styles.sectionTitle}>Benachrichtigungen</Text>
-
-      {/* Daily Reminder */}
-      <View style={styles.reminderRow}>
-        <View style={{ flex: 1 }}>
-          <Text style={styles.label}>Bestell-Erinnerung</Text>
-          <Text style={styles.reminderHint}>
-            Tägliche Erinnerung an deine Bestellung
-          </Text>
-        </View>
-        <Switch
-          value={reminderEnabled}
-          onValueChange={handleReminderToggle}
-          trackColor={{ false: colors.border, true: colors.primary }}
-        />
-      </View>
-
-      {reminderEnabled && (
-        <View style={styles.timePickerSection}>
-          <Text style={styles.label}>Uhrzeit</Text>
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            style={styles.timeScroll}
-            contentContainerStyle={styles.timeScrollContent}
-          >
-            {TIME_OPTIONS.map((opt) => {
-              const isSelected = opt.hour === reminderHour && opt.minute === reminderMinute;
-              return (
-                <Pressable
-                  key={opt.label}
-                  style={[styles.timeChip, isSelected && styles.timeChipActive]}
-                  onPress={() => handleReminderTimeChange(opt.hour, opt.minute)}
-                >
-                  <Text style={[styles.timeChipText, isSelected && styles.timeChipTextActive]}>
-                    {opt.label}
-                  </Text>
-                </Pressable>
-              );
-            })}
-          </ScrollView>
-        </View>
-      )}
-
-      <View style={styles.divider} />
-
-      {/* Location Notifications (existing) */}
-      <Text style={styles.label}>Standort-Benachrichtigungen</Text>
-      <Text style={styles.reminderHint}>
-        Erinnerung um 8:45 basierend auf deinem Standort
-      </Text>
-
-      {companyLocation ? (
-        <View>
-          <Text style={styles.sessionInfo}>
-            Firmenstandort gesetzt
-          </Text>
-          <Pressable style={styles.buttonDanger} onPress={handleRemoveLocation}>
-            <Text style={styles.buttonDangerText}>Standort entfernen</Text>
-          </Pressable>
-        </View>
-      ) : (
-        <Pressable
-          style={[styles.button, styles.buttonPrimary]}
-          onPress={handleSetLocation}
-          disabled={locationSaving}
-        >
-          <Text style={styles.buttonPrimaryText}>
-            {locationSaving ? 'Standort wird ermittelt...' : 'Aktuellen Standort als Firmenstandort setzen'}
-          </Text>
-        </Pressable>
-      )}
-    </View>
-  ) : null;
-
   return (
-    <KeyboardAvoidingView style={{ flex: 1 }} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
-    <ScrollView style={[styles.container, { paddingTop: insets.top }]} contentContainerStyle={isWideLayout ? styles.contentDesktop : styles.content} keyboardShouldPersistTaps="handled">
+    <ScrollView style={[styles.container, { paddingTop: insets.top }]} contentContainerStyle={isWideLayout ? styles.contentDesktop : styles.content}>
       {isWideLayout ? (
         <>
           <View style={styles.desktopRow}>
@@ -563,7 +179,6 @@ export default function SettingsScreen() {
         </>
       )}
     </ScrollView>
-    </KeyboardAvoidingView>
   );
 }
 
@@ -595,35 +210,24 @@ const createStyles = (c: Colors) =>
       ...cardSurface(c),
     },
     sectionTitle: {
-      fontSize: isCompactDesktop ? 15 : 22,
+      fontSize: isCompactDesktop ? 15 : 18,
       fontWeight: '600',
       color: c.textPrimary,
-      marginBottom: isCompactDesktop ? 10 : 16,
-    },
-    sectionSubtitle: {
-      fontSize: isCompactDesktop ? 12 : 13,
-      color: c.textTertiary,
-      marginTop: isCompactDesktop ? -8 : -12,
-      marginBottom: isCompactDesktop ? 10 : 16,
     },
     divider: {
       height: 1,
       backgroundColor: useFlatStyle ? c.border : c.glassHighlight,
       marginVertical: 24,
     },
-    inputGroup: {
-      marginBottom: isCompactDesktop ? 10 : 16,
+    navRow: {
+      flexDirection: 'row' as const,
+      alignItems: 'center' as const,
+      paddingVertical: isCompactDesktop ? 4 : 8,
     },
-    label: {
-      fontSize: isCompactDesktop ? 12 : 13,
-      fontWeight: '600',
-      color: c.textSecondary,
-      marginBottom: isCompactDesktop ? 4 : 6,
-    },
-    input: {
-      fontSize: isCompactDesktop ? 13 : 15,
-      color: c.textPrimary,
-      ...inputField(c),
+    navHint: {
+      fontSize: isCompactDesktop ? 11 : 13,
+      color: c.textTertiary,
+      marginTop: 2,
     },
     buttonRow: {
       flexDirection: 'row',
@@ -644,52 +248,6 @@ const createStyles = (c: Colors) =>
       fontWeight: '700',
       fontSize: isCompactDesktop ? 13 : 15,
     },
-    buttonDanger: {
-      alignSelf: isCompactDesktop ? 'flex-start' as const : undefined,
-      alignItems: 'center' as const,
-      paddingVertical: isCompactDesktop ? 8 : 14,
-      paddingHorizontal: isCompactDesktop ? 16 : 24,
-      ...buttonDanger(c),
-    },
-    buttonDangerText: {
-      color: '#fff',
-      fontWeight: '700',
-      fontSize: isCompactDesktop ? 13 : 15,
-    },
-    sessionSection: {
-      marginTop: isCompactDesktop ? 10 : 16,
-    },
-    sessionInfo: {
-      fontSize: isCompactDesktop ? 13 : 14,
-      color: c.textSecondary,
-      marginBottom: isCompactDesktop ? 8 : 12,
-    },
-    appearanceSection: {
-      marginTop: 32,
-    },
-    themeRow: {
-      flexDirection: 'row',
-      gap: 10,
-    },
-    themeOption: {
-      flex: 1,
-      paddingVertical: isCompactDesktop ? 7 : 12,
-      alignItems: 'center',
-      ...bannerSurface(c),
-    },
-    themeOptionActive: {
-      backgroundColor: useFlatStyle ? c.primarySurface : c.glassPrimary,
-      borderColor: useFlatStyle ? c.primary : undefined,
-      borderBottomColor: c.primary,
-    },
-    themeOptionText: {
-      fontSize: isCompactDesktop ? 12 : 14,
-      fontWeight: '600',
-      color: c.textSecondary,
-    },
-    themeOptionTextActive: {
-      color: c.primary,
-    },
     updateAvailableText: {
       fontSize: isCompactDesktop ? 13 : 14,
       color: c.textSecondary,
@@ -699,43 +257,6 @@ const createStyles = (c: Colors) =>
       fontSize: isCompactDesktop ? 11 : 12,
       color: c.textTertiary,
       marginTop: isCompactDesktop ? 6 : 8,
-    },
-    reminderRow: {
-      flexDirection: 'row' as const,
-      alignItems: 'center' as const,
-      marginBottom: isCompactDesktop ? 8 : 12,
-    },
-    reminderHint: {
-      fontSize: isCompactDesktop ? 11 : 12,
-      color: c.textTertiary,
-      marginTop: 2,
-    },
-    timePickerSection: {
-      marginBottom: isCompactDesktop ? 10 : 16,
-    },
-    timeScroll: {
-      marginTop: isCompactDesktop ? 4 : 8,
-    },
-    timeScrollContent: {
-      gap: isCompactDesktop ? 6 : 8,
-    },
-    timeChip: {
-      paddingHorizontal: isCompactDesktop ? 10 : 14,
-      paddingVertical: isCompactDesktop ? 6 : 10,
-      ...bannerSurface(c),
-    },
-    timeChipActive: {
-      backgroundColor: useFlatStyle ? c.primarySurface : c.glassPrimary,
-      borderColor: useFlatStyle ? c.primary : undefined,
-      borderBottomColor: c.primary,
-    },
-    timeChipText: {
-      fontSize: isCompactDesktop ? 12 : 14,
-      fontWeight: '600' as const,
-      color: c.textSecondary,
-    },
-    timeChipTextActive: {
-      color: c.primary,
     },
     privacyRow: {
       flexDirection: 'row' as const,
@@ -747,40 +268,5 @@ const createStyles = (c: Colors) =>
       color: c.textTertiary,
       textAlign: 'center' as const,
       paddingVertical: 16,
-    },
-    accentLabel: {
-      fontSize: isCompactDesktop ? 12 : 13,
-      fontWeight: '600',
-      color: c.textSecondary,
-      marginTop: isCompactDesktop ? 14 : 20,
-      marginBottom: isCompactDesktop ? 8 : 12,
-    },
-    accentRow: {
-      flexDirection: 'row',
-      justifyContent: 'flex-start',
-      gap: isCompactDesktop ? 12 : 16,
-    },
-    accentOption: {
-      alignItems: 'center',
-      gap: isCompactDesktop ? 4 : 6,
-    },
-    accentCircle: {
-      width: isCompactDesktop ? 28 : 36,
-      height: isCompactDesktop ? 28 : 36,
-      borderRadius: isCompactDesktop ? 14 : 18,
-      borderWidth: 2,
-      borderColor: 'transparent',
-      alignItems: 'center',
-      justifyContent: 'center',
-    },
-    accentCheck: {
-      color: '#fff',
-      fontSize: isCompactDesktop ? 13 : 16,
-      fontWeight: '700',
-    },
-    accentOptionText: {
-      fontSize: isCompactDesktop ? 10 : 12,
-      color: c.textTertiary,
-      fontWeight: '500',
     },
   });

--- a/src/app/app/_layout.tsx
+++ b/src/app/app/_layout.tsx
@@ -87,6 +87,10 @@ function AppContent() {
     <DialogProvider>
       <Stack>
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen name="kantine-login" options={{ headerShown: false, presentation: 'card' }} />
+        <Stack.Screen name="automaten-login" options={{ headerShown: false, presentation: 'card' }} />
+        <Stack.Screen name="notifications" options={{ headerShown: false, presentation: 'card' }} />
+        <Stack.Screen name="appearance" options={{ headerShown: false, presentation: 'card' }} />
       </Stack>
       <StatusBar style="auto" />
     </DialogProvider>

--- a/src/app/app/appearance.tsx
+++ b/src/app/app/appearance.tsx
@@ -1,0 +1,201 @@
+import { useMemo } from 'react';
+import {
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { router } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useFlatStyle, isCompactDesktop } from '../src-rn/utils/platform';
+import { useTheme } from '../src-rn/theme/useTheme';
+import { useThemeStore, ThemePreference } from '../src-rn/store/themeStore';
+import { Colors, ACCENT_COLORS, AccentColorId } from '../src-rn/theme/colors';
+import { bannerSurface, cardSurface } from '../src-rn/theme/platformStyles';
+
+const THEME_OPTIONS: { value: ThemePreference; label: string; icon: string }[] = [
+  { value: 'system', label: 'System', icon: 'phone-portrait-outline' },
+  { value: 'light', label: 'Hell', icon: 'sunny-outline' },
+  { value: 'dark', label: 'Dunkel', icon: 'moon-outline' },
+];
+
+const ACCENT_OPTIONS = Object.entries(ACCENT_COLORS) as [AccentColorId, typeof ACCENT_COLORS[AccentColorId]][];
+
+export default function AppearanceScreen() {
+  const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
+  const styles = useMemo(() => createStyles(colors), [colors]);
+
+  const themePreference = useThemeStore((s) => s.preference);
+  const setThemePreference = useThemeStore((s) => s.setPreference);
+  const accentColor = useThemeStore((s) => s.accentColor);
+  const setAccentColor = useThemeStore((s) => s.setAccentColor);
+
+  return (
+    <ScrollView
+      style={[styles.container, { paddingTop: insets.top }]}
+      contentContainerStyle={styles.content}
+    >
+      <Pressable style={styles.backButton} onPress={() => router.back()}>
+        <Ionicons name="chevron-back" size={24} color={colors.primary} />
+        <Text style={styles.backText}>Einstellungen</Text>
+      </Pressable>
+
+      <Text style={styles.pageTitle}>Darstellung</Text>
+
+      <View style={styles.card}>
+        <Text style={styles.sectionTitle}>Design</Text>
+        <View style={styles.themeRow}>
+          {THEME_OPTIONS.map((opt) => (
+            <Pressable
+              key={opt.value}
+              style={[
+                styles.themeOption,
+                themePreference === opt.value && styles.themeOptionActive,
+              ]}
+              onPress={() => setThemePreference(opt.value)}
+            >
+              <Ionicons
+                name={opt.icon as any}
+                size={isCompactDesktop ? 18 : 22}
+                color={themePreference === opt.value ? colors.primary : colors.textSecondary}
+                style={styles.themeIcon}
+              />
+              <Text
+                style={[
+                  styles.themeOptionText,
+                  themePreference === opt.value && styles.themeOptionTextActive,
+                ]}
+              >
+                {opt.label}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+      </View>
+
+      <View style={styles.card}>
+        <Text style={styles.sectionTitle}>Akzentfarbe</Text>
+        <View style={styles.accentRow}>
+          {ACCENT_OPTIONS.map(([id, config]) => (
+            <Pressable
+              key={id}
+              style={styles.accentOption}
+              onPress={() => setAccentColor(id)}
+            >
+              <View
+                style={[
+                  styles.accentCircle,
+                  { backgroundColor: config.light.primary },
+                  accentColor === id && { borderColor: config.light.primary, borderWidth: 3 },
+                ]}
+              >
+                {accentColor === id && (
+                  <Ionicons name="checkmark" size={isCompactDesktop ? 16 : 20} color="#fff" />
+                )}
+              </View>
+              <Text
+                style={[
+                  styles.accentOptionText,
+                  accentColor === id && { color: colors.primary },
+                ]}
+              >
+                {config.label}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+      </View>
+    </ScrollView>
+  );
+}
+
+const createStyles = (c: Colors) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: c.background,
+    },
+    content: {
+      padding: 20,
+      paddingBottom: 100,
+    },
+    backButton: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      marginBottom: 8,
+      marginLeft: -6,
+    },
+    backText: {
+      fontSize: 17,
+      color: c.primary,
+    },
+    pageTitle: {
+      fontSize: 28,
+      fontWeight: '700',
+      color: c.textPrimary,
+      marginBottom: 24,
+    },
+    card: {
+      padding: isCompactDesktop ? 14 : 20,
+      marginBottom: isCompactDesktop ? 12 : 16,
+      ...cardSurface(c),
+    },
+    sectionTitle: {
+      fontSize: isCompactDesktop ? 15 : 18,
+      fontWeight: '600',
+      color: c.textPrimary,
+      marginBottom: isCompactDesktop ? 10 : 14,
+    },
+    themeRow: {
+      flexDirection: 'row',
+      gap: 10,
+    },
+    themeOption: {
+      flex: 1,
+      paddingVertical: isCompactDesktop ? 10 : 16,
+      alignItems: 'center',
+      ...bannerSurface(c),
+    },
+    themeOptionActive: {
+      backgroundColor: useFlatStyle ? c.primarySurface : c.glassPrimary,
+      borderColor: useFlatStyle ? c.primary : undefined,
+      borderBottomColor: c.primary,
+    },
+    themeIcon: {
+      marginBottom: isCompactDesktop ? 4 : 6,
+    },
+    themeOptionText: {
+      fontSize: isCompactDesktop ? 12 : 14,
+      fontWeight: '600',
+      color: c.textSecondary,
+    },
+    themeOptionTextActive: {
+      color: c.primary,
+    },
+    accentRow: {
+      flexDirection: 'row',
+      justifyContent: 'flex-start',
+      gap: isCompactDesktop ? 12 : 16,
+    },
+    accentOption: {
+      alignItems: 'center',
+      gap: isCompactDesktop ? 4 : 6,
+    },
+    accentCircle: {
+      width: isCompactDesktop ? 28 : 40,
+      height: isCompactDesktop ? 28 : 40,
+      borderRadius: isCompactDesktop ? 14 : 20,
+      borderWidth: 2,
+      borderColor: 'transparent',
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    accentOptionText: {
+      fontSize: isCompactDesktop ? 10 : 12,
+      color: c.textTertiary,
+      fontWeight: '500',
+    },
+  });

--- a/src/app/app/automaten-login.tsx
+++ b/src/app/app/automaten-login.tsx
@@ -1,0 +1,218 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { router } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { isCompactDesktop } from '../src-rn/utils/platform';
+import { useVentopayAuthStore } from '../src-rn/store/ventopayAuthStore';
+import { useTheme } from '../src-rn/theme/useTheme';
+import { useDialog } from '../src-rn/components/DialogProvider';
+import { Colors } from '../src-rn/theme/colors';
+import {
+  inputField,
+  buttonPrimary,
+  buttonDanger,
+} from '../src-rn/theme/platformStyles';
+
+export default function AutomatenLoginScreen() {
+  const { colors } = useTheme();
+  const { alert } = useDialog();
+  const insets = useSafeAreaInsets();
+  const styles = useMemo(() => createStyles(colors), [colors]);
+
+  const {
+    status: ventopayStatus,
+    login: ventopayLogin,
+    logout: ventopayLogout,
+    saveCredentials: ventopaySaveCredentials,
+    getSavedCredentials: ventopayGetSavedCredentials,
+  } = useVentopayAuthStore();
+
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      const creds = await ventopayGetSavedCredentials();
+      if (creds) {
+        setUsername(creds.username);
+        setPassword(creds.password);
+      }
+    })();
+  }, [ventopayGetSavedCredentials]);
+
+  const handleSave = async () => {
+    if (!username || !password) {
+      alert('Fehler', 'Bitte Benutzername und Passwort eingeben');
+      return;
+    }
+    setSaving(true);
+    await ventopaySaveCredentials(username, password);
+    const success = await ventopayLogin(username, password);
+    setSaving(false);
+    if (success) {
+      alert('Gespeichert', 'Automaten-Zugangsdaten sicher gespeichert');
+    } else {
+      const error = useVentopayAuthStore.getState().error;
+      alert('Login fehlgeschlagen', error || 'Anmeldung nicht möglich. Bitte Zugangsdaten prüfen.');
+    }
+  };
+
+  const handleLogout = async () => {
+    await ventopayLogout();
+  };
+
+  return (
+    <KeyboardAvoidingView style={{ flex: 1 }} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
+      <ScrollView
+        style={[styles.container, { paddingTop: insets.top }]}
+        contentContainerStyle={styles.content}
+        keyboardShouldPersistTaps="handled"
+      >
+        <Pressable style={styles.backButton} onPress={() => router.back()}>
+          <Ionicons name="chevron-back" size={24} color={colors.primary} />
+          <Text style={styles.backText}>Einstellungen</Text>
+        </Pressable>
+
+        <Text style={styles.pageTitle}>Automaten-Zugangsdaten</Text>
+        <Text style={styles.subtitle}>Für Automaten und Kassenabrechnungen</Text>
+
+        <View style={styles.inputGroup}>
+          <Text style={styles.label}>Benutzername</Text>
+          <TextInput
+            style={styles.input}
+            value={username}
+            onChangeText={setUsername}
+            placeholder="Benutzername eingeben"
+            placeholderTextColor={colors.textTertiary}
+            autoCapitalize="none"
+            autoCorrect={false}
+          />
+        </View>
+
+        <View style={styles.inputGroup}>
+          <Text style={styles.label}>Passwort</Text>
+          <TextInput
+            style={styles.input}
+            value={password}
+            onChangeText={setPassword}
+            placeholder="Passwort eingeben"
+            placeholderTextColor={colors.textTertiary}
+            secureTextEntry
+            autoCapitalize="none"
+            autoCorrect={false}
+          />
+        </View>
+
+        <Pressable
+          style={[styles.button, styles.buttonPrimary]}
+          onPress={handleSave}
+          disabled={saving}
+        >
+          <Text style={styles.buttonPrimaryText}>
+            {saving ? 'Speichern...' : 'Speichern'}
+          </Text>
+        </Pressable>
+
+        {ventopayStatus === 'authenticated' && (
+          <View style={styles.sessionSection}>
+            <Text style={styles.sessionInfo}>Automaten-Sitzung aktiv</Text>
+            <Pressable style={styles.buttonDanger} onPress={handleLogout}>
+              <Text style={styles.buttonDangerText}>Abmelden</Text>
+            </Pressable>
+          </View>
+        )}
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+}
+
+const createStyles = (c: Colors) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: c.background,
+    },
+    content: {
+      padding: 20,
+      paddingBottom: 100,
+    },
+    backButton: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      marginBottom: 8,
+      marginLeft: -6,
+    },
+    backText: {
+      fontSize: 17,
+      color: c.primary,
+    },
+    pageTitle: {
+      fontSize: 28,
+      fontWeight: '700',
+      color: c.textPrimary,
+      marginBottom: 4,
+    },
+    subtitle: {
+      fontSize: isCompactDesktop ? 12 : 14,
+      color: c.textTertiary,
+      marginBottom: 24,
+    },
+    inputGroup: {
+      marginBottom: isCompactDesktop ? 10 : 16,
+    },
+    label: {
+      fontSize: isCompactDesktop ? 12 : 13,
+      fontWeight: '600',
+      color: c.textSecondary,
+      marginBottom: isCompactDesktop ? 4 : 6,
+    },
+    input: {
+      fontSize: isCompactDesktop ? 13 : 15,
+      color: c.textPrimary,
+      ...inputField(c),
+    },
+    button: {
+      paddingVertical: isCompactDesktop ? 8 : 14,
+      borderRadius: isCompactDesktop ? 4 : 14,
+      alignItems: 'center',
+    },
+    buttonPrimary: {
+      ...buttonPrimary(c),
+    },
+    buttonPrimaryText: {
+      color: '#fff',
+      fontWeight: '700',
+      fontSize: isCompactDesktop ? 13 : 15,
+    },
+    buttonDanger: {
+      alignSelf: isCompactDesktop ? 'flex-start' as const : undefined,
+      alignItems: 'center' as const,
+      paddingVertical: isCompactDesktop ? 8 : 14,
+      paddingHorizontal: isCompactDesktop ? 16 : 24,
+      ...buttonDanger(c),
+    },
+    buttonDangerText: {
+      color: '#fff',
+      fontWeight: '700',
+      fontSize: isCompactDesktop ? 13 : 15,
+    },
+    sessionSection: {
+      marginTop: isCompactDesktop ? 10 : 16,
+    },
+    sessionInfo: {
+      fontSize: isCompactDesktop ? 13 : 14,
+      color: c.textSecondary,
+      marginBottom: isCompactDesktop ? 8 : 12,
+    },
+  });

--- a/src/app/app/kantine-login.tsx
+++ b/src/app/app/kantine-login.tsx
@@ -1,0 +1,215 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { router } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { isCompactDesktop } from '../src-rn/utils/platform';
+import { useAuthStore } from '../src-rn/store/authStore';
+import { useTheme } from '../src-rn/theme/useTheme';
+import { useDialog } from '../src-rn/components/DialogProvider';
+import { Colors } from '../src-rn/theme/colors';
+import {
+  inputField,
+  buttonPrimary,
+  buttonDanger,
+} from '../src-rn/theme/platformStyles';
+
+export default function KantineLoginScreen() {
+  const { colors } = useTheme();
+  const { alert } = useDialog();
+  const insets = useSafeAreaInsets();
+  const styles = useMemo(() => createStyles(colors), [colors]);
+
+  const {
+    status: gourmetStatus,
+    userInfo,
+    login: gourmetLogin,
+    logout: gourmetLogout,
+    saveCredentials: gourmetSaveCredentials,
+    getSavedCredentials: gourmetGetSavedCredentials,
+  } = useAuthStore();
+
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      const creds = await gourmetGetSavedCredentials();
+      if (creds) {
+        setUsername(creds.username);
+        setPassword(creds.password);
+      }
+    })();
+  }, [gourmetGetSavedCredentials]);
+
+  const handleSave = async () => {
+    if (!username || !password) {
+      alert('Fehler', 'Bitte Benutzername und Passwort eingeben');
+      return;
+    }
+    setSaving(true);
+    await gourmetSaveCredentials(username, password);
+    const success = await gourmetLogin(username, password);
+    setSaving(false);
+    if (success) {
+      alert('Gespeichert', 'Kantine-Zugangsdaten sicher gespeichert');
+    } else {
+      const error = useAuthStore.getState().error;
+      alert('Login fehlgeschlagen', error || 'Anmeldung nicht möglich. Bitte Zugangsdaten prüfen.');
+    }
+  };
+
+  const handleLogout = async () => {
+    await gourmetLogout();
+  };
+
+  return (
+    <KeyboardAvoidingView style={{ flex: 1 }} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
+      <ScrollView
+        style={[styles.container, { paddingTop: insets.top }]}
+        contentContainerStyle={styles.content}
+        keyboardShouldPersistTaps="handled"
+      >
+        <Pressable style={styles.backButton} onPress={() => router.back()}>
+          <Ionicons name="chevron-back" size={24} color={colors.primary} />
+          <Text style={styles.backText}>Einstellungen</Text>
+        </Pressable>
+
+        <Text style={styles.pageTitle}>Kantine-Zugangsdaten</Text>
+
+        <View style={styles.inputGroup}>
+          <Text style={styles.label}>Benutzername</Text>
+          <TextInput
+            style={styles.input}
+            value={username}
+            onChangeText={setUsername}
+            placeholder="Benutzername eingeben"
+            placeholderTextColor={colors.textTertiary}
+            autoCapitalize="none"
+            autoCorrect={false}
+          />
+        </View>
+
+        <View style={styles.inputGroup}>
+          <Text style={styles.label}>Passwort</Text>
+          <TextInput
+            style={styles.input}
+            value={password}
+            onChangeText={setPassword}
+            placeholder="Passwort eingeben"
+            placeholderTextColor={colors.textTertiary}
+            secureTextEntry
+            autoCapitalize="none"
+            autoCorrect={false}
+          />
+        </View>
+
+        <Pressable
+          style={[styles.button, styles.buttonPrimary]}
+          onPress={handleSave}
+          disabled={saving}
+        >
+          <Text style={styles.buttonPrimaryText}>
+            {saving ? 'Speichern...' : 'Speichern'}
+          </Text>
+        </Pressable>
+
+        {gourmetStatus === 'authenticated' && (
+          <View style={styles.sessionSection}>
+            <Text style={styles.sessionInfo}>
+              Angemeldet als: {userInfo?.username}
+            </Text>
+            <Pressable style={styles.buttonDanger} onPress={handleLogout}>
+              <Text style={styles.buttonDangerText}>Abmelden</Text>
+            </Pressable>
+          </View>
+        )}
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+}
+
+const createStyles = (c: Colors) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: c.background,
+    },
+    content: {
+      padding: 20,
+      paddingBottom: 100,
+    },
+    backButton: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      marginBottom: 8,
+      marginLeft: -6,
+    },
+    backText: {
+      fontSize: 17,
+      color: c.primary,
+    },
+    pageTitle: {
+      fontSize: 28,
+      fontWeight: '700',
+      color: c.textPrimary,
+      marginBottom: 24,
+    },
+    inputGroup: {
+      marginBottom: isCompactDesktop ? 10 : 16,
+    },
+    label: {
+      fontSize: isCompactDesktop ? 12 : 13,
+      fontWeight: '600',
+      color: c.textSecondary,
+      marginBottom: isCompactDesktop ? 4 : 6,
+    },
+    input: {
+      fontSize: isCompactDesktop ? 13 : 15,
+      color: c.textPrimary,
+      ...inputField(c),
+    },
+    button: {
+      paddingVertical: isCompactDesktop ? 8 : 14,
+      borderRadius: isCompactDesktop ? 4 : 14,
+      alignItems: 'center',
+    },
+    buttonPrimary: {
+      ...buttonPrimary(c),
+    },
+    buttonPrimaryText: {
+      color: '#fff',
+      fontWeight: '700',
+      fontSize: isCompactDesktop ? 13 : 15,
+    },
+    buttonDanger: {
+      alignSelf: isCompactDesktop ? 'flex-start' as const : undefined,
+      alignItems: 'center' as const,
+      paddingVertical: isCompactDesktop ? 8 : 14,
+      paddingHorizontal: isCompactDesktop ? 16 : 24,
+      ...buttonDanger(c),
+    },
+    buttonDangerText: {
+      color: '#fff',
+      fontWeight: '700',
+      fontSize: isCompactDesktop ? 13 : 15,
+    },
+    sessionSection: {
+      marginTop: isCompactDesktop ? 10 : 16,
+    },
+    sessionInfo: {
+      fontSize: isCompactDesktop ? 13 : 14,
+      color: c.textSecondary,
+      marginBottom: isCompactDesktop ? 8 : 12,
+    },
+  });

--- a/src/app/app/notifications.tsx
+++ b/src/app/app/notifications.tsx
@@ -1,0 +1,339 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Linking,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Switch,
+  Text,
+  View,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { router } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useFlatStyle, isCompactDesktop, isNative } from '../src-rn/utils/platform';
+import { useLocationStore } from '../src-rn/store/locationStore';
+import {
+  requestLocationPermissions,
+  requestNotificationPermissions,
+  hasBackgroundLocationPermission,
+  getCurrentPosition,
+  enableNotifications,
+  disableNotifications,
+  registerBackgroundSync,
+} from '../src-rn/utils/notificationService';
+import {
+  getReminderEnabled,
+  setReminderEnabled,
+  getReminderTime,
+  setReminderTime,
+} from '../src-rn/utils/reminderStorage';
+import { useTheme } from '../src-rn/theme/useTheme';
+import { useDialog } from '../src-rn/components/DialogProvider';
+import { Colors } from '../src-rn/theme/colors';
+import {
+  buttonPrimary,
+  buttonDanger,
+  bannerSurface,
+} from '../src-rn/theme/platformStyles';
+
+const TIME_OPTIONS: { hour: number; minute: number; label: string }[] = [];
+for (let h = 11; h <= 13; h++) {
+  for (let m = 0; m < 60; m += 15) {
+    TIME_OPTIONS.push({
+      hour: h,
+      minute: m,
+      label: `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`,
+    });
+  }
+}
+
+export default function NotificationsScreen() {
+  const { colors } = useTheme();
+  const { alert } = useDialog();
+  const insets = useSafeAreaInsets();
+  const styles = useMemo(() => createStyles(colors), [colors]);
+
+  // Location notifications
+  const companyLocation = useLocationStore((s) => s.companyLocation);
+  const setCompanyLocation = useLocationStore((s) => s.setCompanyLocation);
+  const clearCompanyLocation = useLocationStore((s) => s.clearCompanyLocation);
+  const [locationSaving, setLocationSaving] = useState(false);
+
+  // Daily reminder state
+  const [reminderEnabled, setReminderEnabledState] = useState(false);
+  const [reminderHour, setReminderHour] = useState(11);
+  const [reminderMinute, setReminderMinute] = useState(0);
+
+  useEffect(() => {
+    if (!isNative()) return;
+    (async () => {
+      const enabled = await getReminderEnabled();
+      setReminderEnabledState(enabled);
+      const time = await getReminderTime();
+      if (time) {
+        setReminderHour(time.hour);
+        setReminderMinute(time.minute);
+      }
+    })();
+  }, []);
+
+  const handleReminderToggle = async (newValue: boolean) => {
+    if (newValue) {
+      const granted = await requestNotificationPermissions();
+      if (!granted) {
+        alert('Berechtigung fehlt', 'Benachrichtigungen werden für diese Funktion benötigt. Bitte in den Einstellungen aktivieren.');
+        return;
+      }
+      await setReminderTime(reminderHour, reminderMinute);
+      await registerBackgroundSync();
+    }
+    await setReminderEnabled(newValue);
+    setReminderEnabledState(newValue);
+  };
+
+  const handleReminderTimeChange = async (hour: number, minute: number) => {
+    setReminderHour(hour);
+    setReminderMinute(minute);
+    await setReminderTime(hour, minute);
+  };
+
+  const openAppSettings = () => {
+    Linking.openSettings();
+  };
+
+  const handleSetLocation = async () => {
+    setLocationSaving(true);
+    try {
+      const locGranted = await requestLocationPermissions();
+      if (!locGranted) {
+        // Check if foreground was granted but background wasn't (iOS "While Using" only)
+        const hasBg = await hasBackgroundLocationPermission();
+        if (!hasBg) {
+          alert(
+            'Standort „Immer" erforderlich',
+            'Für Standort-Benachrichtigungen muss der Standortzugriff auf „Immer" gesetzt werden.\n\nBitte öffne die Einstellungen und wähle unter Standort „Immer" aus.',
+          );
+          openAppSettings();
+        }
+        setLocationSaving(false);
+        return;
+      }
+      const notifGranted = await requestNotificationPermissions();
+      if (!notifGranted) {
+        alert('Berechtigung fehlt', 'Benachrichtigungen werden für diese Funktion benötigt. Bitte in den Einstellungen aktivieren.');
+        setLocationSaving(false);
+        return;
+      }
+      const position = await getCurrentPosition();
+      setCompanyLocation(position.latitude, position.longitude);
+      await enableNotifications();
+      alert('Gespeichert', 'Firmenstandort gesetzt. Du wirst um 8:45 benachrichtigt, wenn du im Büro bist und nicht bestellt hast.');
+    } catch {
+      alert('Fehler', 'Standort konnte nicht ermittelt werden.');
+    }
+    setLocationSaving(false);
+  };
+
+  const handleRemoveLocation = async () => {
+    clearCompanyLocation();
+    await disableNotifications();
+  };
+
+  return (
+    <ScrollView
+      style={[styles.container, { paddingTop: insets.top }]}
+      contentContainerStyle={styles.content}
+    >
+      <Pressable style={styles.backButton} onPress={() => router.back()}>
+        <Ionicons name="chevron-back" size={24} color={colors.primary} />
+        <Text style={styles.backText}>Einstellungen</Text>
+      </Pressable>
+
+      <Text style={styles.pageTitle}>Benachrichtigungen</Text>
+
+      {/* Daily Reminder */}
+      <Text style={styles.sectionTitle}>Bestell-Erinnerung</Text>
+      <Text style={styles.sectionHint}>
+        Tägliche Erinnerung an deine Bestellung
+      </Text>
+
+      <View style={styles.toggleRow}>
+        <Text style={styles.label}>Aktiviert</Text>
+        <Switch
+          value={reminderEnabled}
+          onValueChange={handleReminderToggle}
+          trackColor={{ false: colors.border, true: colors.primary }}
+        />
+      </View>
+
+      {reminderEnabled && (
+        <View style={styles.timePickerSection}>
+          <Text style={styles.label}>Uhrzeit</Text>
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            style={styles.timeScroll}
+            contentContainerStyle={styles.timeScrollContent}
+          >
+            {TIME_OPTIONS.map((opt) => {
+              const isSelected = opt.hour === reminderHour && opt.minute === reminderMinute;
+              return (
+                <Pressable
+                  key={opt.label}
+                  style={[styles.timeChip, isSelected && styles.timeChipActive]}
+                  onPress={() => handleReminderTimeChange(opt.hour, opt.minute)}
+                >
+                  <Text style={[styles.timeChipText, isSelected && styles.timeChipTextActive]}>
+                    {opt.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </ScrollView>
+        </View>
+      )}
+
+      <View style={styles.divider} />
+
+      {/* Location Notifications */}
+      <Text style={styles.sectionTitle}>Standort-Benachrichtigungen</Text>
+      <Text style={styles.sectionHint}>
+        Erinnerung um 8:45 basierend auf deinem Standort
+      </Text>
+
+      {companyLocation ? (
+        <View>
+          <Text style={styles.statusText}>
+            Firmenstandort gesetzt
+          </Text>
+          <Pressable style={styles.buttonDanger} onPress={handleRemoveLocation}>
+            <Text style={styles.buttonDangerText}>Standort entfernen</Text>
+          </Pressable>
+        </View>
+      ) : (
+        <Pressable
+          style={[styles.button, styles.buttonPrimary]}
+          onPress={handleSetLocation}
+          disabled={locationSaving}
+        >
+          <Text style={styles.buttonPrimaryText}>
+            {locationSaving ? 'Standort wird ermittelt...' : 'Aktuellen Standort als Firmenstandort setzen'}
+          </Text>
+        </Pressable>
+      )}
+    </ScrollView>
+  );
+}
+
+const createStyles = (c: Colors) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: c.background,
+    },
+    content: {
+      padding: 20,
+      paddingBottom: 100,
+    },
+    backButton: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      marginBottom: 8,
+      marginLeft: -6,
+    },
+    backText: {
+      fontSize: 17,
+      color: c.primary,
+    },
+    pageTitle: {
+      fontSize: 28,
+      fontWeight: '700',
+      color: c.textPrimary,
+      marginBottom: 24,
+    },
+    sectionTitle: {
+      fontSize: isCompactDesktop ? 15 : 18,
+      fontWeight: '600',
+      color: c.textPrimary,
+      marginBottom: 4,
+    },
+    sectionHint: {
+      fontSize: isCompactDesktop ? 11 : 13,
+      color: c.textTertiary,
+      marginBottom: isCompactDesktop ? 10 : 16,
+    },
+    divider: {
+      height: 1,
+      backgroundColor: useFlatStyle ? c.border : c.glassHighlight,
+      marginVertical: 24,
+    },
+    toggleRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      marginBottom: isCompactDesktop ? 8 : 12,
+    },
+    label: {
+      fontSize: isCompactDesktop ? 12 : 15,
+      fontWeight: '600',
+      color: c.textSecondary,
+    },
+    timePickerSection: {
+      marginBottom: isCompactDesktop ? 10 : 16,
+    },
+    timeScroll: {
+      marginTop: isCompactDesktop ? 4 : 8,
+    },
+    timeScrollContent: {
+      gap: isCompactDesktop ? 6 : 8,
+    },
+    timeChip: {
+      paddingHorizontal: isCompactDesktop ? 10 : 14,
+      paddingVertical: isCompactDesktop ? 6 : 10,
+      ...bannerSurface(c),
+    },
+    timeChipActive: {
+      backgroundColor: useFlatStyle ? c.primarySurface : c.glassPrimary,
+      borderColor: useFlatStyle ? c.primary : undefined,
+      borderBottomColor: c.primary,
+    },
+    timeChipText: {
+      fontSize: isCompactDesktop ? 12 : 14,
+      fontWeight: '600',
+      color: c.textSecondary,
+    },
+    timeChipTextActive: {
+      color: c.primary,
+    },
+    statusText: {
+      fontSize: isCompactDesktop ? 13 : 14,
+      color: c.textSecondary,
+      marginBottom: isCompactDesktop ? 8 : 12,
+    },
+    button: {
+      paddingVertical: isCompactDesktop ? 8 : 14,
+      borderRadius: isCompactDesktop ? 4 : 14,
+      alignItems: 'center',
+    },
+    buttonPrimary: {
+      ...buttonPrimary(c),
+    },
+    buttonPrimaryText: {
+      color: '#fff',
+      fontWeight: '700',
+      fontSize: isCompactDesktop ? 13 : 15,
+    },
+    buttonDanger: {
+      alignSelf: isCompactDesktop ? 'flex-start' as const : undefined,
+      alignItems: 'center' as const,
+      paddingVertical: isCompactDesktop ? 8 : 14,
+      paddingHorizontal: isCompactDesktop ? 16 : 24,
+      ...buttonDanger(c),
+    },
+    buttonDangerText: {
+      color: '#fff',
+      fontWeight: '700',
+      fontSize: isCompactDesktop ? 13 : 15,
+    },
+  });

--- a/src/app/src-rn/utils/notificationService.ts
+++ b/src/app/src-rn/utils/notificationService.ts
@@ -17,6 +17,17 @@ export async function requestLocationPermissions(): Promise<boolean> {
   const fg = await Location.requestForegroundPermissionsAsync();
   if (fg.status !== 'granted') return false;
   const bg = await Location.requestBackgroundPermissionsAsync();
+  if (bg.status === 'granted') return true;
+  // iOS may not show the "Always Allow" prompt — return 'needs-settings'
+  return false;
+}
+
+/**
+ * Check if background location is already granted (without prompting).
+ * Use this to detect if the user needs to go to Settings.
+ */
+export async function hasBackgroundLocationPermission(): Promise<boolean> {
+  const bg = await Location.getBackgroundPermissionsAsync();
   return bg.status === 'granted';
 }
 


### PR DESCRIPTION
## Summary
- Extract Kantine credentials, Automaten credentials, notifications, and appearance into dedicated sub-pages
- Settings screen now shows compact nav rows with status hints and chevrons
- Appearance page uses `cardSurface()` for platform-aware styling (glass on iOS, material on Android, flat on desktop)
- Guide users to iOS Settings when background location ("Always Allow") is needed
- Limit reminder time picker to 11:00–13:00 range

## Test plan
- [ ] Verify settings screen shows 4 nav rows (Kantine, Automaten, Darstellung, Benachrichtigungen)
- [ ] Tap each row and verify sub-page opens with back navigation
- [ ] Verify appearance page theme switching and accent color selection work
- [ ] Verify credential forms save/login/logout correctly on sub-pages
- [ ] Verify notification time picker only shows 11:00–13:00
- [ ] Verify location permission flow guides to Settings on iOS when "Always" not granted
- [ ] Check desktop layout still uses side-by-side cards