### PR TITLE
fix(security): resolve all Dependabot alerts + dependency hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,67 @@
+version: 2
+updates:
+  # Expo React Native app
+  - package-ecosystem: npm
+    directory: /src/app
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    groups:
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      npm-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
+        # Expo SDK packages must be upgraded together via `npx expo install`,
+        # not individually by Dependabot.
+        exclude-patterns:
+          - "expo*"
+          - "react-native*"
+          - "react"
+          - "react-dom"
+          - "@expo/*"
+
+  # Desktop wrapper (Tauri CLI)
+  - package-ecosystem: npm
+    directory: /src/desktop
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      npm-all:
+        patterns:
+          - "*"
+
+  # Icon generation tooling
+  - package-ecosystem: npm
+    directory: /tools/icon-tools
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      npm-all:
+        patterns:
+          - "*"
+
+  # Tauri Rust backend
+  - package-ecosystem: cargo
+    directory: /src/desktop/src-tauri
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      cargo-all:
+        patterns:
+          - "*"
+
+  # GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -3,6 +3,12 @@ name: Security Audit
 on:
   push:
     branches: [main]
+    paths:
+      - "**/package.json"
+      - "**/package-lock.json"
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - ".github/workflows/security-audit.yml"
   pull_request:
     paths:
       - "**/package.json"
@@ -15,6 +21,10 @@ on:
     - cron: "0 6 * * 1"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   npm-audit:
     runs-on: ubuntu-latest
@@ -23,9 +33,11 @@ jobs:
       matrix:
         dir: [src/app, src/desktop, tools/icon-tools]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
 
@@ -36,10 +48,12 @@ jobs:
   cargo-audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Install cargo-audit
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
         with:
           tool: cargo-audit
 

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,48 @@
+name: Security Audit
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - "**/package.json"
+      - "**/package-lock.json"
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - ".github/workflows/security-audit.yml"
+  schedule:
+    # Weekly sweep so new advisories surface even without code changes
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  npm-audit:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        dir: [src/app, src/desktop, tools/icon-tools]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: npm audit (${{ matrix.dir }})
+        working-directory: ${{ matrix.dir }}
+        run: npm audit --package-lock-only --audit-level=moderate
+
+  cargo-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+
+      - name: cargo audit
+        working-directory: src/desktop/src-tauri
+        run: cargo audit

--- a/src/app/package-lock.json
+++ b/src/app/package-lock.json
@@ -13,7 +13,7 @@
         "@g9k/expo-dynamic-app-icon": "^2.0.8",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@typedigital/telemetrydeck-react": "^0.5.0",
-        "axios": "^1.15.2",
+        "axios": "^1.16.0",
         "cheerio": "^1.0.0-rc.12",
         "expo": "^55.0.0",
         "expo-background-task": "~55.0.10",
@@ -56,12 +56,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -70,29 +70,29 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -118,13 +118,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -146,13 +146,13 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -243,9 +243,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -265,27 +265,27 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -363,27 +363,27 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -404,25 +404,25 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1413,31 +1413,31 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -1464,13 +1464,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1484,9 +1484,9 @@
       "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1501,9 +1501,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -1518,9 +1518,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -1535,9 +1535,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -1552,9 +1552,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
-      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -1569,9 +1569,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -1586,9 +1586,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -1603,9 +1603,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -1620,9 +1620,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -1637,9 +1637,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -1654,9 +1654,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -1671,9 +1671,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -1688,9 +1688,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -1705,9 +1705,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1722,9 +1722,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1739,9 +1739,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -1756,9 +1756,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -1773,9 +1773,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -1790,9 +1790,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -1807,9 +1807,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -1824,9 +1824,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -1841,9 +1841,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -1858,9 +1858,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -1875,9 +1875,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -1892,9 +1892,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -1909,9 +1909,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -2110,9 +2110,9 @@
       }
     },
     "node_modules/@expo/cli/node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -3238,9 +3238,19 @@
       }
     },
     "node_modules/@expo/xcpretty/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -5191,13 +5201,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -5219,6 +5230,31 @@
       "peerDependencies": {
         "axios": ">=0.20.0",
         "tough-cookie": ">=4.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/babel-jest": {
@@ -5645,9 +5681,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -6896,9 +6932,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
-      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -6909,32 +6945,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.3",
-        "@esbuild/android-arm": "0.27.3",
-        "@esbuild/android-arm64": "0.27.3",
-        "@esbuild/android-x64": "0.27.3",
-        "@esbuild/darwin-arm64": "0.27.3",
-        "@esbuild/darwin-x64": "0.27.3",
-        "@esbuild/freebsd-arm64": "0.27.3",
-        "@esbuild/freebsd-x64": "0.27.3",
-        "@esbuild/linux-arm": "0.27.3",
-        "@esbuild/linux-arm64": "0.27.3",
-        "@esbuild/linux-ia32": "0.27.3",
-        "@esbuild/linux-loong64": "0.27.3",
-        "@esbuild/linux-mips64el": "0.27.3",
-        "@esbuild/linux-ppc64": "0.27.3",
-        "@esbuild/linux-riscv64": "0.27.3",
-        "@esbuild/linux-s390x": "0.27.3",
-        "@esbuild/linux-x64": "0.27.3",
-        "@esbuild/netbsd-arm64": "0.27.3",
-        "@esbuild/netbsd-x64": "0.27.3",
-        "@esbuild/openbsd-arm64": "0.27.3",
-        "@esbuild/openbsd-x64": "0.27.3",
-        "@esbuild/openharmony-arm64": "0.27.3",
-        "@esbuild/sunos-x64": "0.27.3",
-        "@esbuild/win32-arm64": "0.27.3",
-        "@esbuild/win32-ia32": "0.27.3",
-        "@esbuild/win32-x64": "0.27.3"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -8026,16 +8062,16 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -8343,9 +8379,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -10926,9 +10962,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -11071,9 +11107,9 @@
       }
     },
     "node_modules/jsdom/node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12100,9 +12136,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "funding": [
         {
           "type": "github",
@@ -12787,9 +12823,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.49",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "funding": [
         {
           "type": "opencollective",
@@ -12806,7 +12842,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -13742,9 +13778,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -14225,9 +14261,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14645,12 +14681,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {
@@ -15063,9 +15103,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.3.0"

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -18,7 +18,7 @@
     "@g9k/expo-dynamic-app-icon": "^2.0.8",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@typedigital/telemetrydeck-react": "^0.5.0",
-    "axios": "^1.15.2",
+    "axios": "^1.16.0",
     "cheerio": "^1.0.0-rc.12",
     "expo": "^55.0.0",
     "expo-background-task": "~55.0.10",
@@ -64,7 +64,19 @@
     "@tootallnate/once": ">=3.0.1",
     "@xmldom/xmldom": "^0.8.13",
     "follow-redirects": ">=1.16.0",
-    "lodash": ">=4.18.0"
+    "lodash": ">=4.18.0",
+    "@babel/core": "^7.29.6",
+    "brace-expansion@^5.0.0": "^5.0.6",
+    "esbuild": "^0.28.1",
+    "form-data": "^4.0.6",
+    "js-yaml@^3.0.0": "^3.14.3",
+    "js-yaml@^4.0.0": "^4.1.2",
+    "postcss": "^8.5.10",
+    "shell-quote": "^1.8.4",
+    "tmp": "^0.2.6",
+    "uuid": "^11.1.1",
+    "ws@^7.0.0": "^7.5.11",
+    "ws@^8.0.0": "^8.21.0"
   },
   "private": true
 }

--- a/src/app/src-rn/__tests__/api/gourmetApi.test.ts
+++ b/src/app/src-rn/__tests__/api/gourmetApi.test.ts
@@ -103,6 +103,20 @@ describe('GourmetApi', () => {
       expect(api.isAuthenticated()).toBe(true);
     });
 
+    it('re-fetches the start page when the login response lacks user info fields', async () => {
+      const bareLoggedInPage =
+        '<html><a href="https://alaclickneu.gourmet.at/einstellungen/" class="navbar-link">Einstellungen</a></html>';
+      mockGet.mockResolvedValueOnce(loginPage);
+      mockPostForm.mockResolvedValueOnce(bareLoggedInPage);
+      mockGet.mockResolvedValueOnce(loginSuccess);
+
+      const api = new GourmetApi();
+      const userInfo = await api.login('testuser', 'testpass');
+
+      expect(mockGet).toHaveBeenCalledTimes(2);
+      expect(userInfo.eaterId).toBe('EATER-TEST-456');
+    });
+
     it('logs out stale session before login when native cookies persist', async () => {
       const api = new GourmetApi();
 
@@ -176,6 +190,75 @@ describe('GourmetApi', () => {
 
       expect(mockGet).toHaveBeenCalledTimes(1);
       expect(items.length).toBe(2);
+    });
+
+    it('re-fetches the first page after session re-login', async () => {
+      const api = new GourmetApi();
+      await loginApi(api);
+
+      // First GET returns unauthenticated page -> triggers re-login
+      mockGet.mockResolvedValueOnce(loginFailed);
+      // Re-login sequence
+      mockGet.mockResolvedValueOnce(loginPage);
+      mockPostForm.mockResolvedValueOnce(loginSuccess);
+      // Re-fetch page 0
+      mockGet.mockResolvedValueOnce(menusPage1);
+
+      const items = await api.getMenus();
+
+      expect(items.length).toBe(2);
+    });
+
+    it('recovers user info from the menus page when missing', async () => {
+      const api = new GourmetApi();
+      // No login: userInfo is null, but the session cookie is still valid
+      mockGet.mockResolvedValueOnce(menusPage0);
+      mockGet.mockResolvedValueOnce(menusPage1);
+
+      await api.getMenus();
+
+      expect(api.getUserInfo()).toEqual({
+        username: 'TestUser',
+        shopModelId: 'SM-TEST-123',
+        eaterId: 'EATER-TEST-456',
+        staffGroupId: 'SG-TEST-789',
+      });
+    });
+
+    it('tolerates a logged-in page without user info fields', async () => {
+      const api = new GourmetApi();
+      const bareLoggedInPage =
+        '<html><a href="https://alaclickneu.gourmet.at/einstellungen/" class="navbar-link">Einstellungen</a></html>';
+      mockGet.mockResolvedValueOnce(bareLoggedInPage);
+
+      const items = await api.getMenus();
+
+      expect(items).toEqual([]);
+      expect(api.getUserInfo()).toBeNull();
+    });
+  });
+
+  describe('session expiry', () => {
+    it('throws SessionExpiredError when session is gone and no credentials are stored', async () => {
+      const api = new GourmetApi();
+      mockGet.mockResolvedValueOnce(loginFailed);
+
+      await expect(api.getOrders()).rejects.toThrow('Session expired');
+    });
+  });
+
+  describe('getUserInfo', () => {
+    it('returns null before login and the user info after login', async () => {
+      const api = new GourmetApi();
+      expect(api.getUserInfo()).toBeNull();
+
+      await loginApi(api);
+      expect(api.getUserInfo()).toEqual({
+        username: 'TestUser',
+        shopModelId: 'SM-TEST-123',
+        eaterId: 'EATER-TEST-456',
+        staffGroupId: 'SG-TEST-789',
+      });
     });
   });
 
@@ -291,6 +374,23 @@ describe('GourmetApi', () => {
 
       expect(mockPostForm).not.toHaveBeenCalled();
     });
+
+    it('re-fetches the orders page after session re-login', async () => {
+      const api = new GourmetApi();
+      await loginApi(api);
+
+      // First GET returns unauthenticated page -> triggers re-login
+      mockGet.mockResolvedValueOnce(loginFailed);
+      mockGet.mockResolvedValueOnce(loginPage);
+      mockPostForm.mockResolvedValueOnce(loginSuccess);
+      // Re-fetch orders (editMode True -> nothing to confirm)
+      mockGet.mockResolvedValueOnce(ordersPage);
+
+      await api.confirmOrders();
+
+      // Only the re-login POST, no edit mode toggle
+      expect(mockPostForm).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('cancelOrders', () => {
@@ -313,6 +413,46 @@ describe('GourmetApi', () => {
           __ncforminfo: 'NCFORM-TOKEN-CANCEL-POS001-BBB',
         })
       );
+    });
+
+    it('enters edit mode first when not already in it, and exits afterwards', async () => {
+      const api = new GourmetApi();
+      await loginApi(api);
+
+      // Orders page with editMode="True" (NOT in edit mode)
+      mockGet.mockResolvedValueOnce(ordersPage);
+      // POST to enter edit mode
+      mockPostForm.mockResolvedValueOnce('');
+      // Re-fetch shows edit mode active (editMode="False")
+      mockGet.mockResolvedValueOnce(ordersPageEditMode);
+      // Cancel POST
+      mockPostForm.mockResolvedValueOnce('');
+      // Re-fetch after cancel (still in edit mode)
+      mockGet.mockResolvedValueOnce(ordersPageEditMode);
+      // Exit edit mode POST
+      mockPostForm.mockResolvedValueOnce('');
+
+      await api.cancelOrders(['POS-001']);
+
+      expect(mockPostForm).toHaveBeenCalledTimes(3);
+      // 1st call enters edit mode with the tokens from the normal orders page
+      expect(mockPostForm.mock.calls[0][1]).toMatchObject({ editMode: 'True' });
+      // 2nd call is the cancellation itself
+      expect(mockPostForm.mock.calls[1][1]).toMatchObject({ cp_PositionId: 'POS-001' });
+      // 3rd call exits edit mode
+      expect(mockPostForm.mock.calls[2][1]).toMatchObject({ editMode: 'False' });
+    });
+
+    it('throws when entering edit mode fails', async () => {
+      const api = new GourmetApi();
+      await loginApi(api);
+
+      mockGet.mockResolvedValueOnce(ordersPage);
+      mockPostForm.mockResolvedValueOnce('');
+      // Re-fetch still shows editMode="True" -> edit mode was not entered
+      mockGet.mockResolvedValueOnce(ordersPage);
+
+      await expect(api.cancelOrders(['POS-001'])).rejects.toThrow('Failed to enter edit mode');
     });
   });
 
@@ -356,6 +496,45 @@ describe('GourmetApi', () => {
           checkLastMonthNumber: '0',
         }
       );
+    });
+  });
+
+  describe('getBillings edge cases', () => {
+    it('throws when not logged in', async () => {
+      const api = new GourmetApi();
+      await expect(api.getBillings('0')).rejects.toThrow('Not logged in');
+    });
+
+    it('handles a raw array response without the Billings wrapper', async () => {
+      const api = new GourmetApi();
+      await loginApi(api);
+
+      mockGet.mockResolvedValueOnce(loginSuccess);
+      mockPostJson.mockResolvedValueOnce([
+        {
+          BillNr: 20001,
+          BillDate: '2026-06-01T12:00:00',
+          Location: 'Betriebsrestaurant Wien',
+          BillingItemInfo: [],
+          Billing: 2.50,
+        },
+      ]);
+
+      const bills = await api.getBillings('1');
+
+      expect(bills).toHaveLength(1);
+      expect(bills[0].billNr).toBe(20001);
+      expect(bills[0].billDate).toBeInstanceOf(Date);
+    });
+
+    it('returns [] when the response has no Billings array', async () => {
+      const api = new GourmetApi();
+      await loginApi(api);
+
+      mockGet.mockResolvedValueOnce(loginSuccess);
+      mockPostJson.mockResolvedValueOnce({});
+
+      expect(await api.getBillings('0')).toEqual([]);
     });
   });
 

--- a/src/app/src-rn/__tests__/api/gourmetParser.test.ts
+++ b/src/app/src-rn/__tests__/api/gourmetParser.test.ts
@@ -300,3 +300,58 @@ describe('extractLogoutFormTokens', () => {
     );
   });
 });
+
+describe('parser edge cases', () => {
+  it('detects Unknown category for titles that match no known pattern', () => {
+    const html = `
+      <div class="row hide-sm-down">
+        <div class="meal">
+          <a class="open_info menu-article-detail" data-id="m-x" data-date="02-10-2026"></a>
+          <div class="title">WOCHENANGEBOT<div class="subtitle">Special</div></div>
+        </div>
+      </div>`;
+
+    const items = parseMenuItems(html);
+
+    expect(items).toHaveLength(1);
+    expect(items[0].category).toBe(GourmetMenuCategory.Unknown);
+  });
+
+  it('extractEditModeFormData throws when the form is missing its tokens', () => {
+    const html = '<form class="form-toggleEditMode"><input name="editMode" value="True" /></form>';
+    expect(() => extractEditModeFormData(html)).toThrow('Could not extract edit mode form data');
+  });
+
+  it('extractCancelOrderFormData falls back to matching by position input', () => {
+    const html = `
+      <form id="someOtherId">
+        <input name="cp_PositionId" value="POS-77" />
+        <input name="cp_EatingCycleId_POS-77" value="EC-77" />
+        <input name="cp_Date_POS-77" value="10.02.2026 00:00:00" />
+        <input name="ufprt" value="UFPRT-77" />
+        <input name="__ncforminfo" value="NC-77" />
+      </form>`;
+
+    const data = extractCancelOrderFormData(html, 'POS-77');
+
+    expect(data).toEqual({
+      positionId: 'POS-77',
+      eatingCycleId: 'EC-77',
+      date: '10.02.2026 00:00:00',
+      ufprt: 'UFPRT-77',
+      ncforminfo: 'NC-77',
+    });
+  });
+
+  it('extractCancelOrderFormData throws when tokens are missing', () => {
+    const html = '<form><input name="cp_PositionId" value="POS-88" /></form>';
+    expect(() => extractCancelOrderFormData(html, 'POS-88')).toThrow(
+      'Could not extract cancel form data for position: POS-88'
+    );
+  });
+
+  it('extractLogoutFormTokens throws when the logout form lacks tokens', () => {
+    const html = '<form><button id="btnHeaderLogout">Logout</button></form>';
+    expect(() => extractLogoutFormTokens(html)).toThrow('Could not extract logout form tokens');
+  });
+});

--- a/src/app/src-rn/__tests__/api/ventopayParser.test.ts
+++ b/src/app/src-rn/__tests__/api/ventopayParser.test.ts
@@ -109,3 +109,50 @@ describe('parseTransactions', () => {
     expect(transactions).toEqual([]);
   });
 });
+
+describe('parser edge cases', () => {
+  it('falls back to Date parsing for non-German timestamp formats', () => {
+    const html = `
+      <div class="content">
+        <div class="transact" id="tx-iso">
+          <a href="rechnung.aspx?id=tx-iso">
+            <div class="transact_title">€ 2,50 (Café + Co. Automaten)</div>
+            <div class="transact_timestamp">2026-02-09T11:49:00</div>
+          </a>
+        </div>
+      </div>`;
+
+    const [tx] = parseTransactions(html);
+
+    expect(tx.date.getFullYear()).toBe(2026);
+    expect(tx.date.getMonth()).toBe(1);
+    expect(tx.date.getDate()).toBe(9);
+  });
+
+  it('falls back to raw amount parsing when the title has no restaurant parentheses', () => {
+    const html = `
+      <div class="content">
+        <div class="transact" id="tx-basic">
+          <a href="rechnung.aspx?id=tx-basic">
+            <div class="transact_title">1,80</div>
+            <div class="transact_timestamp">09. Feb 2026 - 11:49 Uhr</div>
+          </a>
+        </div>
+      </div>`;
+
+    const [tx] = parseTransactions(html);
+
+    expect(tx.amount).toBe(1.8);
+    expect(tx.restaurant).toBe('1,80');
+  });
+
+  it('skips transact divs without an id or title', () => {
+    const html = `
+      <div class="content">
+        <div class="transact"><a><div class="transact_title">€ 1,00 (X)</div></a></div>
+        <div class="transact" id="tx-no-title"><a></a></div>
+      </div>`;
+
+    expect(parseTransactions(html)).toEqual([]);
+  });
+});

--- a/src/app/src-rn/__tests__/store/authStore.test.ts
+++ b/src/app/src-rn/__tests__/store/authStore.test.ts
@@ -200,3 +200,14 @@ describe('useAuthStore', () => {
     });
   });
 });
+
+describe('demo mode', () => {
+  it('logs in with demo credentials without touching the real API', async () => {
+    const ok = await useAuthStore.getState().login('demo', 'demo1234!');
+
+    expect(ok).toBe(true);
+    expect(useAuthStore.getState().status).toBe('authenticated');
+    expect(useAuthStore.getState().userInfo).not.toBeNull();
+    expect(mockLogin).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/src-rn/__tests__/store/billingStore.test.ts
+++ b/src/app/src-rn/__tests__/store/billingStore.test.ts
@@ -27,9 +27,10 @@ jest.mock('../../store/authStore', () => {
 
 jest.mock('../../store/ventopayAuthStore', () => {
   const mockApi = { getTransactions: jest.fn() };
+  const state = { api: mockApi, status: 'authenticated' };
   return {
     useVentopayAuthStore: {
-      getState: () => ({ api: mockApi, status: 'authenticated' }),
+      getState: () => state,
       setState: jest.fn(),
       subscribe: jest.fn(),
     },
@@ -76,8 +77,11 @@ function makeTransaction(overrides: Partial<VentopayTransaction> = {}): Ventopay
   };
 }
 
-beforeEach(() => {
+beforeEach(async () => {
+  const AsyncStorage = require('@react-native-async-storage/async-storage').default;
+  await AsyncStorage.clear();
   jest.clearAllMocks();
+  (useVentopayAuthStore as any).getState().status = 'authenticated';
   useBillingStore.setState({
     gourmetMonths: {},
     ventopayMonths: {},
@@ -216,9 +220,165 @@ describe('billingStore', () => {
       expect(useBillingStore.getState().selectedMonthIndex).toBe(2);
     });
 
+    it('triggers both fetches for the selected month', () => {
+      mockGourmetApi.getBillings.mockResolvedValue([]);
+      mockVentopayApi.getTransactions.mockResolvedValue([]);
+
+      useBillingStore.getState().selectMonth(0);
+
+      expect(mockGourmetApi.getBillings).toHaveBeenCalledWith('0');
+      expect(mockVentopayApi.getTransactions).toHaveBeenCalled();
+    });
+
     it('updates sourceFilter', () => {
       useBillingStore.getState().setSourceFilter('ventopay');
       expect(useBillingStore.getState().sourceFilter).toBe('ventopay');
+    });
+  });
+
+  describe('selected month getters', () => {
+    it('return null when no data exists for the selected month', () => {
+      expect(useBillingStore.getState().getSelectedGourmetBilling()).toBeNull();
+      expect(useBillingStore.getState().getSelectedVentopayBilling()).toBeNull();
+    });
+
+    it('return the data of the selected month', async () => {
+      mockGourmetApi.getBillings.mockResolvedValue([makeBill()]);
+      mockVentopayApi.getTransactions.mockResolvedValue([makeTransaction()]);
+      await useBillingStore.getState().fetchBilling(0);
+      await useBillingStore.getState().fetchVentopayBilling(0);
+
+      const gourmet = useBillingStore.getState().getSelectedGourmetBilling();
+      const ventopay = useBillingStore.getState().getSelectedVentopayBilling();
+      expect(gourmet?.totalBilling).toBe(3.00);
+      expect(ventopay?.total).toBe(4.50);
+    });
+
+    it('return null for an out-of-range month index', () => {
+      useBillingStore.setState({ selectedMonthIndex: 7 });
+      expect(useBillingStore.getState().getSelectedGourmetBilling()).toBeNull();
+      expect(useBillingStore.getState().getSelectedVentopayBilling()).toBeNull();
+    });
+  });
+
+  describe('fetchBilling guards', () => {
+    it('returns early for an invalid month offset', async () => {
+      await useBillingStore.getState().fetchBilling(7);
+      expect(mockGourmetApi.getBillings).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the selected month when no offset is given', async () => {
+      mockGourmetApi.getBillings.mockResolvedValue([]);
+      mockVentopayApi.getTransactions.mockResolvedValue([]);
+      useBillingStore.setState({ selectedMonthIndex: 1 });
+
+      await useBillingStore.getState().fetchBilling();
+      await useBillingStore.getState().fetchVentopayBilling();
+
+      expect(mockGourmetApi.getBillings).toHaveBeenCalledWith('1');
+      expect(mockVentopayApi.getTransactions).toHaveBeenCalled();
+    });
+
+    it('uses a fallback message for non-Error rejections', async () => {
+      mockGourmetApi.getBillings.mockRejectedValue('boom');
+
+      await useBillingStore.getState().fetchBilling(0);
+
+      expect(useBillingStore.getState().error).toBe('Abrechnung konnte nicht geladen werden');
+    });
+
+    it('skips fetching while another fetch is in flight', async () => {
+      useBillingStore.setState({ loading: true });
+      await useBillingStore.getState().fetchBilling(0);
+      expect(mockGourmetApi.getBillings).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('fetchVentopayBilling guards and errors', () => {
+    it('returns early for an invalid month offset', async () => {
+      await useBillingStore.getState().fetchVentopayBilling(7);
+      expect(mockVentopayApi.getTransactions).not.toHaveBeenCalled();
+    });
+
+    it('skips fetch for past months with existing transactions', async () => {
+      const options = useBillingStore.getState().getMonthOptions();
+      const pastKey = options[1].key;
+      useBillingStore.setState({
+        ventopayMonths: {
+          [pastKey]: {
+            monthKey: pastKey,
+            label: options[1].label,
+            transactions: [makeTransaction()],
+            total: 4.50,
+            fetchedAt: Date.now(),
+          },
+        },
+      });
+
+      await useBillingStore.getState().fetchVentopayBilling(1);
+
+      expect(mockVentopayApi.getTransactions).not.toHaveBeenCalled();
+    });
+
+    it('skips fetch when Ventopay is not authenticated', async () => {
+      (useVentopayAuthStore as any).getState().status = 'unauthenticated';
+
+      await useBillingStore.getState().fetchVentopayBilling(0);
+
+      expect(mockVentopayApi.getTransactions).not.toHaveBeenCalled();
+    });
+
+    it('warns but does not set error on failure', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+      mockVentopayApi.getTransactions.mockRejectedValue(new Error('Ventopay down'));
+
+      await useBillingStore.getState().fetchVentopayBilling(0);
+
+      expect(useBillingStore.getState().error).toBeNull();
+      expect(warnSpy).toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it('caches transactions to AsyncStorage', async () => {
+      const AsyncStorage = require('@react-native-async-storage/async-storage').default;
+      mockVentopayApi.getTransactions.mockResolvedValue([makeTransaction()]);
+
+      await useBillingStore.getState().fetchVentopayBilling(0);
+
+      const call = AsyncStorage.setItem.mock.calls.find(([k]: [string]) => k.startsWith('ventopay_billing_'));
+      expect(call).toBeDefined();
+    });
+  });
+
+  describe('loadCachedMonths', () => {
+    it('restores gourmet and ventopay months with revived dates', async () => {
+      // Populate the cache through real fetches, then reset in-memory state
+      mockGourmetApi.getBillings.mockResolvedValue([makeBill()]);
+      mockVentopayApi.getTransactions.mockResolvedValue([makeTransaction()]);
+      await useBillingStore.getState().fetchBilling(0);
+      await useBillingStore.getState().fetchVentopayBilling(0);
+      useBillingStore.setState({ gourmetMonths: {}, ventopayMonths: {} });
+
+      await useBillingStore.getState().loadCachedMonths();
+
+      const options = useBillingStore.getState().getMonthOptions();
+      const gourmet = useBillingStore.getState().gourmetMonths[options[0].key];
+      const ventopay = useBillingStore.getState().ventopayMonths[options[0].key];
+
+      expect(gourmet).toBeDefined();
+      expect(gourmet.bills[0].billDate).toBeInstanceOf(Date);
+      expect(gourmet.totalBilling).toBe(3.00);
+      expect(gourmet.fetchedAt).toBe(0);
+
+      expect(ventopay).toBeDefined();
+      expect(ventopay.transactions[0].date).toBeInstanceOf(Date);
+      expect(ventopay.total).toBe(4.50);
+    });
+
+    it('leaves months without cached data absent', async () => {
+      await useBillingStore.getState().loadCachedMonths();
+      expect(Object.keys(useBillingStore.getState().gourmetMonths)).toHaveLength(0);
+      expect(Object.keys(useBillingStore.getState().ventopayMonths)).toHaveLength(0);
     });
   });
 });

--- a/src/app/src-rn/__tests__/store/menuStore.test.ts
+++ b/src/app/src-rn/__tests__/store/menuStore.test.ts
@@ -54,6 +54,15 @@ import { MENU_CACHE_VALIDITY_MS } from '../../utils/constants';
 
 const mockApi = (useAuthStore as any).getState().api;
 
+// A date safely in the future so submitOrders tests never hit the ordering
+// cutoff, regardless of when the suite runs.
+const FUTURE_DATE = (() => {
+  const d = new Date();
+  d.setDate(d.getDate() + 14);
+  d.setHours(0, 0, 0, 0);
+  return d;
+})();
+
 function makeItem(overrides: Partial<import('../../types/menu').GourmetMenuItem> = {}): import('../../types/menu').GourmetMenuItem {
   return {
     id: 'menu-001',
@@ -256,7 +265,7 @@ describe('menuStore', () => {
   describe('submitOrders', () => {
     beforeEach(() => {
       const items = [
-        makeItem({ id: 'menu-001', day: new Date(2026, 5, 10) }),
+        makeItem({ id: 'menu-001', day: FUTURE_DATE }),
       ];
       useMenuStore.setState({ items });
       mockApi.addToCart.mockResolvedValue(undefined);
@@ -271,7 +280,7 @@ describe('menuStore', () => {
     });
 
     it('calls addToCart and confirmOrders', async () => {
-      const date = new Date(2026, 5, 10);
+      const date = FUTURE_DATE;
       useMenuStore.getState().togglePendingOrder('menu-001', date);
 
       await useMenuStore.getState().submitOrders();
@@ -282,11 +291,11 @@ describe('menuStore', () => {
 
     it('submits multiple menus for the same date', async () => {
       const items = [
-        makeItem({ id: 'menu-001', day: new Date(2026, 5, 10), category: GourmetMenuCategory.Menu1 }),
-        makeItem({ id: 'menu-002', day: new Date(2026, 5, 10), category: GourmetMenuCategory.Menu2 }),
+        makeItem({ id: 'menu-001', day: FUTURE_DATE, category: GourmetMenuCategory.Menu1 }),
+        makeItem({ id: 'menu-002', day: FUTURE_DATE, category: GourmetMenuCategory.Menu2 }),
       ];
       useMenuStore.setState({ items });
-      const date = new Date(2026, 5, 10);
+      const date = FUTURE_DATE;
       useMenuStore.getState().togglePendingOrder('menu-001', date);
       useMenuStore.getState().togglePendingOrder('menu-002', date);
 
@@ -301,7 +310,7 @@ describe('menuStore', () => {
     });
 
     it('clears pendingOrders after submit', async () => {
-      const date = new Date(2026, 5, 10);
+      const date = FUTURE_DATE;
       useMenuStore.getState().togglePendingOrder('menu-001', date);
 
       await useMenuStore.getState().submitOrders();
@@ -310,7 +319,7 @@ describe('menuStore', () => {
     });
 
     it('sets error on failure', async () => {
-      const date = new Date(2026, 5, 10);
+      const date = FUTURE_DATE;
       useMenuStore.getState().togglePendingOrder('menu-001', date);
       mockApi.addToCart.mockRejectedValue(new Error('Cart error'));
 
@@ -320,7 +329,7 @@ describe('menuStore', () => {
     });
 
     it('cancels orders from pendingCancellations before adding new ones', async () => {
-      const date = new Date(2026, 5, 10);
+      const date = FUTURE_DATE;
       const items = [
         makeItem({ id: 'menu-001', day: date, ordered: true, category: GourmetMenuCategory.Menu1 }),
         makeItem({ id: 'menu-002', day: date, ordered: false, category: GourmetMenuCategory.Menu2 }),
@@ -348,7 +357,7 @@ describe('menuStore', () => {
     });
 
     it('handles cancellation-only submit (no new orders)', async () => {
-      const date = new Date(2026, 5, 10);
+      const date = FUTURE_DATE;
       const items = [
         makeItem({ id: 'menu-001', day: date, ordered: true, category: GourmetMenuCategory.Menu1 }),
       ];
@@ -406,7 +415,7 @@ describe('menuStore', () => {
     });
 
     it('clears both pendingOrders and pendingCancellations after submit', async () => {
-      const date = new Date(2026, 5, 10);
+      const date = FUTURE_DATE;
       const items = [
         makeItem({ id: 'menu-001', day: date, ordered: true, category: GourmetMenuCategory.Menu1 }),
         makeItem({ id: 'menu-002', day: date, ordered: false, category: GourmetMenuCategory.Menu2 }),

--- a/src/app/src-rn/__tests__/store/menuStore.test.ts
+++ b/src/app/src-rn/__tests__/store/menuStore.test.ts
@@ -356,6 +356,39 @@ describe('menuStore', () => {
       expect(mockApi.confirmOrders).toHaveBeenCalled();
     });
 
+    it('warns when a pending cancellation cannot be resolved to an order', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const items = [
+        makeItem({ id: 'menu-001', day: FUTURE_DATE, ordered: true, category: GourmetMenuCategory.Menu1 }),
+        makeItem({ id: 'menu-009', day: FUTURE_DATE, ordered: false, category: GourmetMenuCategory.Menu2 }),
+      ];
+      useMenuStore.setState({ items });
+
+      // Default orderStore mock has no orders, so the cancellation cannot resolve
+      useMenuStore.getState().togglePendingOrder('menu-001', FUTURE_DATE);
+
+      await useMenuStore.getState().submitOrders();
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Could not resolve all cancellations'));
+      warnSpy.mockRestore();
+    });
+
+    it('sets the cutoff error when all new orders are blocked and nothing to cancel', async () => {
+      const { isOrderingCutoff } = require('../../utils/dateUtils') as { isOrderingCutoff: jest.Mock };
+      isOrderingCutoff.mockReturnValue(true);
+
+      try {
+        useMenuStore.getState().togglePendingOrder('menu-001', FUTURE_DATE);
+
+        await useMenuStore.getState().submitOrders();
+
+        expect(useMenuStore.getState().error).toBe(ORDERING_CUTOFF_MESSAGE);
+        expect(mockApi.addToCart).not.toHaveBeenCalled();
+      } finally {
+        isOrderingCutoff.mockRestore();
+      }
+    });
+
     it('handles cancellation-only submit (no new orders)', async () => {
       const date = FUTURE_DATE;
       const items = [
@@ -545,6 +578,60 @@ describe('menuStore', () => {
     it('loadCachedMenus does nothing when cache is empty', async () => {
       await useMenuStore.getState().loadCachedMenus();
       expect(useMenuStore.getState().items).toEqual([]);
+    });
+
+    it('loadCachedMenus discards a corrupt cache entry', async () => {
+      const AsyncStorage = require('@react-native-async-storage/async-storage').default;
+      await AsyncStorage.setItem('menus_items', '{not valid json');
+
+      await useMenuStore.getState().loadCachedMenus();
+
+      expect(useMenuStore.getState().items).toEqual([]);
+    });
+  });
+
+  describe('refreshAvailability merge details', () => {
+    it('appends brand-new items that are not in the cache', async () => {
+      const cached = makeItem({ id: 'menu-001', day: FUTURE_DATE, available: true });
+      useMenuStore.setState({ items: [cached] });
+
+      const freshExisting = makeItem({ id: 'menu-001', day: FUTURE_DATE, available: false, ordered: true });
+      const freshNew = makeItem({ id: 'menu-002', day: FUTURE_DATE, category: GourmetMenuCategory.Menu2 });
+      mockApi.getMenus.mockResolvedValue([freshExisting, freshNew]);
+
+      await useMenuStore.getState().refreshAvailability();
+
+      const items = useMenuStore.getState().items;
+      expect(items).toHaveLength(2);
+      expect(items[0].available).toBe(false);
+      expect(items[0].ordered).toBe(true);
+      expect(items[1].id).toBe('menu-002');
+    });
+
+    it('fails silently and keeps cached items on refresh error', async () => {
+      const cached = makeItem({ id: 'menu-001', day: FUTURE_DATE });
+      useMenuStore.setState({ items: [cached] });
+      mockApi.getMenus.mockRejectedValue(new Error('network'));
+
+      await useMenuStore.getState().refreshAvailability();
+
+      expect(useMenuStore.getState().refreshing).toBe(false);
+      expect(useMenuStore.getState().error).toBeNull();
+      expect(useMenuStore.getState().items).toEqual([cached]);
+    });
+  });
+
+  describe('clearPendingChanges', () => {
+    it('clears both pending sets', () => {
+      useMenuStore.setState({
+        pendingOrders: new Set(['menu-001|2026-08-01']),
+        pendingCancellations: new Set(['menu-002|2026-08-01']),
+      });
+
+      useMenuStore.getState().clearPendingChanges();
+
+      expect(useMenuStore.getState().pendingOrders.size).toBe(0);
+      expect(useMenuStore.getState().pendingCancellations.size).toBe(0);
     });
   });
 });

--- a/src/app/src-rn/__tests__/store/orderStore.test.ts
+++ b/src/app/src-rn/__tests__/store/orderStore.test.ts
@@ -27,6 +27,19 @@ jest.mock('../../store/authStore', () => {
   };
 });
 
+const mockCancelGeofenceNotification = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../utils/notificationService', () => ({
+  cancelGeofenceNotification: mockCancelGeofenceNotification,
+}));
+const mockCheckDailyReminder = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../utils/dailyReminderCheck', () => ({
+  checkDailyReminder: mockCheckDailyReminder,
+}));
+const mockCheckCancelReminder = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../utils/cancelReminderCheck', () => ({
+  checkCancelReminder: mockCheckCancelReminder,
+}));
+
 import { useOrderStore } from '../../store/orderStore';
 import { useAuthStore } from '../../store/authStore';
 import { GourmetOrderedMenu } from '../../types/order';
@@ -86,6 +99,53 @@ describe('orderStore', () => {
       expect(useOrderStore.getState().error).toBe('Fetch failed');
       expect(useOrderStore.getState().loading).toBe(false);
     });
+
+    it('uses a fallback message for non-Error rejections', async () => {
+      mockApi.getOrders.mockRejectedValue('boom');
+
+      await useOrderStore.getState().fetchOrders();
+
+      expect(useOrderStore.getState().error).toBe('Bestellungen konnten nicht geladen werden');
+    });
+
+    it('skips fetch while another fetch is in flight', async () => {
+      useOrderStore.setState({ loading: true });
+
+      await useOrderStore.getState().fetchOrders();
+
+      expect(mockApi.getOrders).not.toHaveBeenCalled();
+    });
+
+    it('cancels the geofence notification and updates reminders when an order exists today', async () => {
+      mockApi.getOrders.mockResolvedValue([makeOrder({ date: new Date() })]);
+
+      await useOrderStore.getState().fetchOrders();
+
+      expect(mockCancelGeofenceNotification).toHaveBeenCalled();
+      expect(mockCheckDailyReminder).toHaveBeenCalled();
+      expect(mockCheckCancelReminder).toHaveBeenCalled();
+    });
+
+    it('does not cancel the geofence notification without an order today', async () => {
+      const nextWeek = new Date();
+      nextWeek.setDate(nextWeek.getDate() + 7);
+      mockApi.getOrders.mockResolvedValue([makeOrder({ date: nextWeek })]);
+
+      await useOrderStore.getState().fetchOrders();
+
+      expect(mockCancelGeofenceNotification).not.toHaveBeenCalled();
+      expect(mockCheckDailyReminder).toHaveBeenCalled();
+    });
+
+    it('ignores notification helper failures', async () => {
+      mockApi.getOrders.mockResolvedValue([makeOrder({ date: new Date() })]);
+      mockCancelGeofenceNotification.mockRejectedValueOnce(new Error('no permission'));
+
+      await useOrderStore.getState().fetchOrders();
+
+      expect(useOrderStore.getState().error).toBeNull();
+      expect(useOrderStore.getState().orders).toHaveLength(1);
+    });
   });
 
   describe('confirmOrders', () => {
@@ -105,6 +165,24 @@ describe('orderStore', () => {
       await useOrderStore.getState().confirmOrders();
 
       expect(mockApi.getOrders).toHaveBeenCalled();
+    });
+
+    it('sets error on failure', async () => {
+      mockApi.confirmOrders.mockRejectedValue(new Error('Confirm failed'));
+
+      await useOrderStore.getState().confirmOrders();
+
+      expect(useOrderStore.getState().error).toBe('Confirm failed');
+      expect(useOrderStore.getState().loading).toBe(false);
+      expect(mockApi.getOrders).not.toHaveBeenCalled();
+    });
+
+    it('uses a fallback message for non-Error rejections', async () => {
+      mockApi.confirmOrders.mockRejectedValue('boom');
+
+      await useOrderStore.getState().confirmOrders();
+
+      expect(useOrderStore.getState().error).toBe('Bestellungen konnten nicht bestätigt werden');
     });
   });
 
@@ -129,6 +207,33 @@ describe('orderStore', () => {
       resolveFn!();
       await promise;
       expect(useOrderStore.getState().cancellingId).toBe(null);
+    });
+
+    it('skips when another cancellation is in flight', async () => {
+      useOrderStore.setState({ cancellingId: 'P9' });
+
+      await useOrderStore.getState().cancelOrder('P1');
+
+      expect(mockApi.cancelOrders).not.toHaveBeenCalled();
+      expect(useOrderStore.getState().cancellingId).toBe('P9');
+    });
+
+    it('sets error and clears cancellingId on failure', async () => {
+      mockApi.cancelOrders.mockRejectedValue(new Error('Cancel failed'));
+
+      await useOrderStore.getState().cancelOrder('P1');
+
+      expect(useOrderStore.getState().error).toBe('Cancel failed');
+      expect(useOrderStore.getState().cancellingId).toBe(null);
+      expect(mockApi.getOrders).not.toHaveBeenCalled();
+    });
+
+    it('uses a fallback message for non-Error rejections', async () => {
+      mockApi.cancelOrders.mockRejectedValue('boom');
+
+      await useOrderStore.getState().cancelOrder('P1');
+
+      expect(useOrderStore.getState().error).toBe('Bestellung konnte nicht storniert werden');
     });
   });
 
@@ -200,6 +305,16 @@ describe('orderStore', () => {
     it('loadCachedOrders does nothing when cache is empty', async () => {
       await useOrderStore.getState().loadCachedOrders();
       expect(useOrderStore.getState().orders).toEqual([]);
+    });
+
+    it('loadCachedOrders discards a corrupt cache entry', async () => {
+      const AsyncStorage = require('@react-native-async-storage/async-storage').default;
+      await AsyncStorage.setItem('orders_list', '{not valid json');
+
+      await useOrderStore.getState().loadCachedOrders();
+
+      expect(useOrderStore.getState().orders).toEqual([]);
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith('orders_list');
     });
   });
 });

--- a/src/app/src-rn/__tests__/store/ventopayAuthStore.test.ts
+++ b/src/app/src-rn/__tests__/store/ventopayAuthStore.test.ts
@@ -142,3 +142,13 @@ describe('useVentopayAuthStore', () => {
     });
   });
 });
+
+describe('demo mode', () => {
+  it('logs in with demo credentials without touching the real API', async () => {
+    const ok = await useVentopayAuthStore.getState().login('demo', 'demo1234!');
+
+    expect(ok).toBe(true);
+    expect(useVentopayAuthStore.getState().status).toBe('authenticated');
+    expect(mockLogin).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/src-rn/__tests__/theme/colors.test.ts
+++ b/src/app/src-rn/__tests__/theme/colors.test.ts
@@ -74,3 +74,33 @@ describe('getColorsForAccent', () => {
     }
   });
 });
+
+describe('flat style variants', () => {
+  function loadColors(flat: boolean) {
+    jest.resetModules();
+    jest.doMock('../../utils/platform', () => ({ useFlatStyle: flat }));
+    const mod = require('../../theme/colors');
+    jest.dontMock('../../utils/platform');
+    return mod as typeof import('../../theme/colors');
+  }
+
+  it('uses opaque glass colors when flat style is active (Android/desktop)', () => {
+    const { LightColors: light, DarkColors: dark, ACCENT_COLORS: accents } = loadColors(true);
+    expect(light.glassSurface).toBe('#ffffff');
+    expect(light.glassPrimary).toBe('#FFF1EB');
+    expect(dark.glassSurface).toBe('#1C1C1E');
+    expect(dark.glassPrimary).toBe('#2A1A10');
+    expect(accents.ocean.light.glassPrimary).toBe('#EBF2FC');
+    expect(accents.ocean.dark.glassPrimary).toBe('#101A2A');
+  });
+
+  it('uses translucent rgba glass colors when flat style is off (iOS)', () => {
+    const { LightColors: light, DarkColors: dark, ACCENT_COLORS: accents } = loadColors(false);
+    expect(light.glassSurface).toBe('rgba(255,255,255,0.70)');
+    expect(light.glassPrimary).toBe('rgba(212,80,26,0.08)');
+    expect(dark.glassSurface).toBe('rgba(28,28,30,0.72)');
+    expect(dark.glassPrimary).toBe('rgba(255,107,53,0.14)');
+    expect(accents.ocean.light.glassPrimary).toBe('rgba(37,99,168,0.08)');
+    expect(accents.ocean.dark.glassPrimary).toBe('rgba(74,144,217,0.14)');
+  });
+});

--- a/src/app/src-rn/__tests__/utils/desktopUpdater.web.test.ts
+++ b/src/app/src-rn/__tests__/utils/desktopUpdater.web.test.ts
@@ -62,6 +62,80 @@ describe('desktopUpdater.web', () => {
     expect(invokeMock).toHaveBeenCalledWith('install_update', undefined);
   });
 
+  it('alerts "latest version" when no update is available on user-initiated check', async () => {
+    invokeMock.mockResolvedValue(null);
+    const { checkForDesktopUpdates, useUpdateStore } = loadModule(true);
+
+    await checkForDesktopUpdates(true);
+
+    expect(alertMock).toHaveBeenCalledWith('You are on the latest version.');
+    expect(useUpdateStore.getState().pendingVersion).toBeNull();
+  });
+
+  it('stays silent on background checks that find an update', async () => {
+    invokeMock.mockResolvedValue('1.5.0');
+    const { checkForDesktopUpdates, useUpdateStore } = loadModule(true);
+
+    await checkForDesktopUpdates(false);
+
+    expect(useUpdateStore.getState().pendingVersion).toBe('1.5.0');
+    expect(alertMock).not.toHaveBeenCalled();
+  });
+
+  it('stays silent on background check failures', async () => {
+    invokeMock.mockRejectedValue(new Error('offline'));
+    const { checkForDesktopUpdates, useUpdateStore } = loadModule(true);
+
+    await checkForDesktopUpdates(false);
+
+    expect(alertMock).not.toHaveBeenCalled();
+    expect(useUpdateStore.getState().checking).toBe(false);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+
+  it('runs a background download check 5s after startup on desktop', async () => {
+    invokeMock.mockResolvedValue('1.6.0');
+    const { useUpdateStore } = loadModule(true);
+
+    expect(invokeMock).not.toHaveBeenCalled();
+    await jest.advanceTimersByTimeAsync(5000);
+
+    expect(invokeMock).toHaveBeenCalledWith('download_update', undefined);
+    expect(useUpdateStore.getState().pendingVersion).toBe('1.6.0');
+    expect(useUpdateStore.getState().checking).toBe(false);
+    expect(alertMock).not.toHaveBeenCalled();
+  });
+
+  it('skips hourly background checks once a version is pending', async () => {
+    invokeMock.mockResolvedValue('1.6.0');
+    loadModule(true);
+
+    await jest.advanceTimersByTimeAsync(5000);
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+
+    await jest.advanceTimersByTimeAsync(60 * 60 * 1000);
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows errors in the background startup check', async () => {
+    invokeMock.mockRejectedValue(new Error('network down'));
+    const { useUpdateStore } = loadModule(true);
+
+    await jest.advanceTimersByTimeAsync(5000);
+
+    expect(useUpdateStore.getState().pendingVersion).toBeNull();
+    expect(useUpdateStore.getState().checking).toBe(false);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+
+  it('does not schedule background checks outside desktop', async () => {
+    loadModule(false);
+
+    await jest.advanceTimersByTimeAsync(60 * 60 * 1000);
+
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
   it('alerts on user-initiated check failure', async () => {
     invokeMock.mockRejectedValue(new Error('network'));
     const { checkForDesktopUpdates, useUpdateStore } = loadModule(true);

--- a/src/app/src-rn/__tests__/utils/notificationLogStorage.test.ts
+++ b/src/app/src-rn/__tests__/utils/notificationLogStorage.test.ts
@@ -1,0 +1,206 @@
+jest.mock('@react-native-async-storage/async-storage', () => {
+  const store: Record<string, string> = {};
+  return {
+    __esModule: true,
+    default: {
+      getItem: jest.fn((key: string) => Promise.resolve(store[key] ?? null)),
+      setItem: jest.fn((key: string, value: string) => { store[key] = value; return Promise.resolve(); }),
+      removeItem: jest.fn((key: string) => { delete store[key]; return Promise.resolve(); }),
+      clear: jest.fn(() => { Object.keys(store).forEach(k => delete store[k]); return Promise.resolve(); }),
+      multiGet: jest.fn((keys: string[]) =>
+        Promise.resolve(keys.map((k) => [k, store[k] ?? null] as [string, string | null]))
+      ),
+    },
+  };
+});
+
+// jest.config.js maps '.*/utils/notificationLogStorage$' to a manual mock for all
+// other suites. Requiring with an explicit .ts extension dodges that mapping so
+// this suite exercises the real implementation.
+const storage = require('../../utils/notificationLogStorage.ts') as
+  typeof import('../../utils/notificationLogStorage');
+
+const AsyncStorage = require('@react-native-async-storage/async-storage').default;
+
+const UNTIL_KEY = 'notification_debug_log_activated_until';
+const ENTRIES_KEY = 'notification_debug_log_entries';
+
+beforeEach(async () => {
+  await AsyncStorage.clear();
+  jest.clearAllMocks();
+});
+
+describe('notificationLogStorage', () => {
+  describe('getLogActivatedUntil', () => {
+    it('returns null when never activated', async () => {
+      expect(await storage.getLogActivatedUntil()).toBeNull();
+    });
+
+    it('returns the stored timestamp', async () => {
+      await AsyncStorage.setItem(UNTIL_KEY, '1234567890');
+      expect(await storage.getLogActivatedUntil()).toBe(1234567890);
+    });
+
+    it('returns null for a corrupt (non-numeric) value', async () => {
+      await AsyncStorage.setItem(UNTIL_KEY, 'not-a-number');
+      expect(await storage.getLogActivatedUntil()).toBeNull();
+    });
+  });
+
+  describe('activateLog', () => {
+    it('sets the activation window and clears old entries', async () => {
+      await AsyncStorage.setItem(ENTRIES_KEY, '[{"old":true}]');
+      const before = Date.now();
+
+      await storage.activateLog(2);
+
+      const until = await storage.getLogActivatedUntil();
+      expect(until).toBeGreaterThanOrEqual(before + 2 * 60 * 60 * 1000);
+      expect(until).toBeLessThanOrEqual(Date.now() + 2 * 60 * 60 * 1000);
+      expect(await AsyncStorage.getItem(ENTRIES_KEY)).toBeNull();
+    });
+
+    it('defaults to a 24 hour window', async () => {
+      const before = Date.now();
+      await storage.activateLog();
+      const until = await storage.getLogActivatedUntil();
+      expect(until).toBeGreaterThanOrEqual(before + 24 * 60 * 60 * 1000);
+    });
+  });
+
+  describe('clearLog', () => {
+    it('removes activation window and entries', async () => {
+      await storage.activateLog();
+      await storage.appendLogEntry('geofence', 'info', 'test');
+
+      await storage.clearLog();
+
+      expect(await storage.getLogActivatedUntil()).toBeNull();
+      expect(await storage.getLogEntries()).toEqual([]);
+    });
+  });
+
+  describe('isLogActive', () => {
+    it('is false when never activated', async () => {
+      expect(await storage.isLogActive()).toBe(false);
+    });
+
+    it('is true within the activation window', async () => {
+      await storage.activateLog(1);
+      expect(await storage.isLogActive()).toBe(true);
+    });
+
+    it('is false after the window expired', async () => {
+      await AsyncStorage.setItem(UNTIL_KEY, String(Date.now() - 1000));
+      expect(await storage.isLogActive()).toBe(false);
+    });
+  });
+
+  describe('getLogEntries', () => {
+    it('returns [] when nothing is stored', async () => {
+      expect(await storage.getLogEntries()).toEqual([]);
+    });
+
+    it('returns [] for corrupt JSON', async () => {
+      await AsyncStorage.setItem(ENTRIES_KEY, '{not json');
+      expect(await storage.getLogEntries()).toEqual([]);
+    });
+
+    it('returns parsed entries', async () => {
+      const entries = [{ ts: '2026-01-01T00:00:00Z', subsystem: 'geofence', level: 'info', event: 'e1' }];
+      await AsyncStorage.setItem(ENTRIES_KEY, JSON.stringify(entries));
+      expect(await storage.getLogEntries()).toEqual(entries);
+    });
+  });
+
+  describe('appendLogEntry', () => {
+    it('is a no-op when the log is not activated', async () => {
+      await storage.appendLogEntry('geofence', 'info', 'ignored');
+      expect(await storage.getLogEntries()).toEqual([]);
+    });
+
+    it('is a no-op when the activation window has expired', async () => {
+      await AsyncStorage.setItem(UNTIL_KEY, String(Date.now() - 1000));
+      await storage.appendLogEntry('geofence', 'info', 'ignored');
+      expect(await storage.getLogEntries()).toEqual([]);
+    });
+
+    it('is a no-op when the stored window is corrupt', async () => {
+      await AsyncStorage.setItem(UNTIL_KEY, 'garbage');
+      await storage.appendLogEntry('geofence', 'info', 'ignored');
+      expect(await storage.getLogEntries()).toEqual([]);
+    });
+
+    it('appends an entry with timestamp and detail when active', async () => {
+      await storage.activateLog();
+
+      await storage.appendLogEntry('order-sync', 'error', 'fetch_failed', 'status=500');
+
+      const entries = await storage.getLogEntries();
+      expect(entries).toHaveLength(1);
+      expect(entries[0].subsystem).toBe('order-sync');
+      expect(entries[0].level).toBe('error');
+      expect(entries[0].event).toBe('fetch_failed');
+      expect(entries[0].detail).toBe('status=500');
+      expect(new Date(entries[0].ts).getTime()).not.toBeNaN();
+    });
+
+    it('omits the detail field when not provided', async () => {
+      await storage.activateLog();
+
+      await storage.appendLogEntry('daily-reminder', 'guard', 'time_guard_fail');
+
+      const entries = await storage.getLogEntries();
+      expect(entries[0]).not.toHaveProperty('detail');
+    });
+
+    it('starts fresh when existing entries are corrupt', async () => {
+      await storage.activateLog();
+      await AsyncStorage.setItem(ENTRIES_KEY, '{corrupt');
+
+      await storage.appendLogEntry('menu-check', 'info', 'new_entry');
+
+      const entries = await storage.getLogEntries();
+      expect(entries).toHaveLength(1);
+      expect(entries[0].event).toBe('new_entry');
+    });
+
+    it('caps stored entries at 200, dropping the oldest', async () => {
+      await storage.activateLog();
+      const existing = Array.from({ length: 200 }, (_, i) => ({
+        ts: '2026-01-01T00:00:00Z', subsystem: 'geofence', level: 'info', event: `e${i}`,
+      }));
+      await AsyncStorage.setItem(ENTRIES_KEY, JSON.stringify(existing));
+
+      await storage.appendLogEntry('geofence', 'info', 'e200');
+
+      const entries = await storage.getLogEntries();
+      expect(entries).toHaveLength(200);
+      expect(entries[0].event).toBe('e1');
+      expect(entries[199].event).toBe('e200');
+    });
+
+    it('never throws when storage fails', async () => {
+      AsyncStorage.multiGet.mockRejectedValueOnce(new Error('disk full'));
+      await expect(storage.appendLogEntry('geofence', 'info', 'x')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('formatLogForEmail', () => {
+    it('returns a placeholder for an empty log', () => {
+      expect(storage.formatLogForEmail([])).toBe('(keine Einträge aufgezeichnet)');
+    });
+
+    it('formats entries with and without detail', () => {
+      const text = storage.formatLogForEmail([
+        { ts: '2026-01-01T08:00:00Z', subsystem: 'geofence', level: 'info', event: 'enter' },
+        { ts: '2026-01-01T08:05:00Z', subsystem: 'order-sync', level: 'error', event: 'fail', detail: 'status=500' },
+      ]);
+
+      expect(text).toBe(
+        '[2026-01-01T08:00:00Z] [geofence] [INFO] enter\n' +
+        '[2026-01-01T08:05:00Z] [order-sync] [ERROR] fail\n  status=500'
+      );
+    });
+  });
+});

--- a/src/app/src-rn/__tests__/utils/tauriHttp.web.test.ts
+++ b/src/app/src-rn/__tests__/utils/tauriHttp.web.test.ts
@@ -82,6 +82,175 @@ describe('tauriHttp.web', () => {
     expect(response.headers['set-cookie']).toEqual(['SessId=abc; Path=/']);
   });
 
+  function getAdapter() {
+    const axios = require('axios').default;
+    axios.create({});
+    return axiosCreateMock.mock.calls[0][0].adapter;
+  }
+
+  function mockOkResponse(body = '{}') {
+    invokeMock.mockResolvedValue({
+      status: 200,
+      headers: {},
+      setCookies: [],
+      body,
+      url: 'https://example.test/',
+    });
+  }
+
+  it('throws when Tauri IPC is not available', async () => {
+    loadModule(true);
+    const adapter = getAdapter();
+    delete (globalThis as any).__TAURI_INTERNALS__;
+
+    await expect(adapter({ url: 'https://example.test/', headers: {} }))
+      .rejects.toThrow('Tauri IPC not available');
+  });
+
+  it('passes an absolute URL through untouched and joins relative URLs without slash', async () => {
+    loadModule(true);
+    const adapter = getAdapter();
+    mockOkResponse();
+
+    await adapter({ url: 'https://example.test/abs', method: 'get', headers: {} });
+    expect(invokeMock.mock.calls[0][1].request.url).toBe('https://example.test/abs');
+
+    await adapter({ baseURL: 'https://example.test', url: 'rel', method: 'get', headers: {} });
+    expect(invokeMock.mock.calls[1][1].request.url).toBe('https://example.test/rel');
+  });
+
+  it('extracts FormData into formData and strips the Content-Type', async () => {
+    loadModule(true);
+    const adapter = getAdapter();
+    mockOkResponse();
+
+    const form = new FormData();
+    form.append('Username', 'user');
+    form.append('ufprt', 'token');
+
+    await adapter({
+      url: 'https://example.test/start/',
+      method: 'post',
+      data: form,
+      headers: { 'Content-Type': 'multipart/form-data' },
+    });
+
+    const request = invokeMock.mock.calls[0][1].request;
+    expect(request.formData).toEqual({ Username: 'user', ufprt: 'token' });
+    expect(request.body).toBeUndefined();
+    expect(request.headers['Content-Type']).toBeUndefined();
+  });
+
+  it('converts a plain object to formData when Content-Type is multipart', async () => {
+    loadModule(true);
+    const adapter = getAdapter();
+    mockOkResponse();
+
+    await adapter({
+      url: 'https://example.test/start/',
+      method: 'post',
+      data: { Username: 'user', RememberMe: 'false' },
+      headers: { 'content-type': 'multipart/form-data' },
+    });
+
+    const request = invokeMock.mock.calls[0][1].request;
+    expect(request.formData).toEqual({ Username: 'user', RememberMe: 'false' });
+    expect(request.headers['content-type']).toBeUndefined();
+  });
+
+  it('passes string data through as the raw body', async () => {
+    loadModule(true);
+    const adapter = getAdapter();
+    mockOkResponse();
+
+    await adapter({
+      url: 'https://example.test/',
+      method: 'post',
+      data: 'raw-body=1',
+      headers: {},
+    });
+
+    expect(invokeMock.mock.calls[0][1].request.body).toBe('raw-body=1');
+  });
+
+  it('url-encodes object data without a JSON content type', async () => {
+    loadModule(true);
+    const adapter = getAdapter();
+    mockOkResponse();
+
+    await adapter({
+      url: 'https://example.test/',
+      method: 'post',
+      data: { a: '1', b: 'x y' },
+      headers: {},
+    });
+
+    expect(invokeMock.mock.calls[0][1].request.body).toBe('a=1&b=x+y');
+  });
+
+  it('keeps the body as a string when responseType is text', async () => {
+    loadModule(true);
+    const adapter = getAdapter();
+    mockOkResponse('{"looks":"like json"}');
+
+    const response = await adapter({
+      url: 'https://example.test/',
+      method: 'get',
+      responseType: 'text',
+      headers: {},
+    });
+
+    expect(response.data).toBe('{"looks":"like json"}');
+  });
+
+  it('rejects with an axios-like error on non-2xx status', async () => {
+    loadModule(true);
+    const adapter = getAdapter();
+    invokeMock.mockResolvedValue({
+      status: 404,
+      headers: {},
+      setCookies: [],
+      body: 'not found',
+      url: 'https://example.test/missing',
+    });
+
+    await expect(adapter({ url: 'https://example.test/missing', method: 'get', headers: {} }))
+      .rejects.toMatchObject({
+        message: 'Request failed with status 404',
+        isAxiosError: true,
+        response: { status: 404 },
+      });
+  });
+
+  it('honours a custom validateStatus', async () => {
+    loadModule(true);
+    const adapter = getAdapter();
+    invokeMock.mockResolvedValue({
+      status: 302,
+      headers: { location: '/redirect' },
+      setCookies: [],
+      body: '',
+      url: 'https://example.test/',
+    });
+
+    const response = await adapter({
+      url: 'https://example.test/',
+      method: 'get',
+      headers: {},
+      validateStatus: (s: number) => s < 400,
+    });
+
+    expect(response.status).toBe(302);
+  });
+
+  it('resetTauriHttp is a no-op without Tauri IPC', async () => {
+    const { resetTauriHttp } = loadModule(true);
+    delete (globalThis as any).__TAURI_INTERNALS__;
+
+    await expect(resetTauriHttp()).resolves.toBeUndefined();
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
   it('does not patch axios.create on non-desktop', () => {
     loadModule(false);
     const axios = require('axios').default;

--- a/src/desktop/src-tauri/Cargo.lock
+++ b/src/desktop/src-tauri/Cargo.lock
@@ -2710,9 +2710,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/src/desktop/src-tauri/Cargo.lock
+++ b/src/desktop/src-tauri/Cargo.lock
@@ -2760,9 +2760,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -3404,7 +3404,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "snack-pilot"
-version = "1.4.2"
+version = "1.4.4"
 dependencies = [
  "keyring",
  "reqwest 0.12.28",

--- a/tools/icon-tools/package-lock.json
+++ b/tools/icon-tools/package-lock.json
@@ -27,9 +27,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -44,9 +44,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -61,9 +61,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -78,9 +78,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -95,9 +95,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -112,9 +112,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -129,9 +129,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -146,9 +146,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -163,9 +163,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -180,9 +180,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -197,9 +197,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -214,9 +214,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -231,9 +231,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -248,9 +248,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -265,9 +265,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -282,9 +282,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -299,9 +299,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -316,9 +316,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -333,9 +333,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -350,9 +350,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -367,9 +367,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -384,9 +384,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -401,9 +401,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -418,9 +418,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -435,9 +435,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -452,9 +452,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -953,9 +953,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -966,32 +966,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/fsevents": {

--- a/tools/icon-tools/package.json
+++ b/tools/icon-tools/package.json
@@ -15,5 +15,8 @@
     "@types/node": "^20.0.0",
     "tsx": "^4.21.0",
     "typescript": "~5.9.2"
+  },
+  "overrides": {
+    "esbuild": "^0.28.1"
   }
 }


### PR DESCRIPTION
## What

Resolves all 21 open Dependabot alerts and adds long-term hardening so new advisories get caught and fixed automatically.

### Vulnerability fixes
- **src/app**: bump `axios` to ^1.16.0 (8 alerts incl. MITM via prototype pollution); pin vulnerable transitives via npm overrides: `ws` (7.x + 8.x DoS), `form-data` (CRLF injection), `shell-quote` (critical escaping bug), `tmp` (path traversal), `uuid`, `brace-expansion`, `postcss`, `esbuild`, `@babel/core`, `js-yaml` → **npm audit: 0 vulnerabilities**
- **tools/icon-tools**: override `esbuild` to ^0.28.1 → 0 vulnerabilities
- **src/desktop/src-tauri**: `rand` 0.9.2 → 0.9.3 (RUSTSEC advisory)

### Hardening
- `.github/dependabot.yml`: weekly grouped updates for all 3 npm manifests, cargo, and GitHub Actions. Expo/RN packages are excluded from version bumps (they must move together via `npx expo install`), but security updates still cover everything.
- `security-audit` workflow: `npm audit` + `cargo audit` on lockfile-touching PRs, pushes to main, and a weekly schedule.
- Enabled Dependabot automated security-fix PRs on the repo (settings change, not part of this diff).

### Test fix (pre-existing)
`menuStore` submitOrders tests hardcoded 2026-06-10 as the order date; once that date passed the ordering cutoff, 5 tests started failing on main. Replaced with a dynamically computed future date.

## Verification
- All 340 tests pass (`npm test`)
- `npm audit`: 0 vulnerabilities in all three npm manifests
- No scraping logic touched; axios 1.16 is a minor bump within the ^1.x range already in use