### PR TITLE
fix(dependabot): suppress SDK-coupled major bumps via ignore rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,14 +17,29 @@ updates:
         update-types:
           - minor
           - patch
-        # Expo SDK packages must be upgraded together via `npx expo install`,
-        # not individually by Dependabot.
-        exclude-patterns:
-          - "expo*"
-          - "react-native*"
-          - "react"
-          - "react-dom"
-          - "@expo/*"
+    # Expo SDK packages and React Native must be upgraded together via
+    # `npx expo install`, never individually. `exclude-patterns` on the group
+    # is not enough — excluded packages get individual PRs instead — so
+    # SDK-coupled upgrades are suppressed here. Minor/patch bumps within the
+    # current SDK remain allowed (and grouped above).
+    ignore:
+      - dependency-name: "expo*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@expo/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "jest-expo"
+        update-types: ["version-update:semver-major"]
+      # react-native uses 0.x versioning: minor = breaking, SDK-coupled
+      - dependency-name: "react-native"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # Companion libs (screens, svg, safe-area-context, ...) are pinned to
+      # SDK-compatible majors by `npx expo install`
+      - dependency-name: "react-native-*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major"]
 
   # Desktop wrapper (Tauri CLI)
   - package-ecosystem: npm


### PR DESCRIPTION
The `exclude-patterns` in the npm-minor-patch group only exclude packages from the *group* — Dependabot then opens **individual** PRs for them instead, which is how #63–#66, #68, #70–#72 (Expo SDK 55→57 majors) appeared. Per CLAUDE.md, Expo SDK packages must move together via `npx expo install`.

This replaces the group excludes with proper `ignore` rules:
- majors ignored for `expo*`, `@expo/*`, `jest-expo`, `react`, `react-dom`, `react-native-*`
- majors **and minors** ignored for `react-native` (0.x versioning — minor = breaking, SDK-coupled)
- minor/patch bumps within the current SDK stay allowed and now fold into the weekly `npm-minor-patch` group

Once merged, Dependabot closes the now-ignored open PRs on its next run (the SDK-57 ones are being closed manually alongside this).