### PR TITLE
fix(security): mitigate RUSTSEC-2026-0194 (quick-xml quadratic DoS)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,9 +32,11 @@ updates:
       # react-native uses 0.x versioning: minor = breaking, SDK-coupled
       - dependency-name: "react-native"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
-      # Companion libs (screens, svg, safe-area-context, ...) are pinned to
-      # SDK-compatible majors by `npx expo install`
+      # Companion libs (screens, svg, safe-area-context, async-storage, ...)
+      # are pinned to SDK-compatible majors by `npx expo install`
       - dependency-name: "react-native-*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@react-native-*"
         update-types: ["version-update:semver-major"]
       - dependency-name: "react"
         update-types: ["version-update:semver-major"]

--- a/src/desktop/src-tauri/.cargo/audit.toml
+++ b/src/desktop/src-tauri/.cargo/audit.toml
@@ -1,0 +1,13 @@
+# Accepted-risk advisories for `cargo audit` (used by the security-audit CI job).
+# Each entry must document why it is ignored and when to revisit.
+
+[advisories]
+ignore = [
+    # quick-xml < 0.41: quadratic runtime parsing start tags with many
+    # duplicate-checked attributes (DoS on untrusted XML). Unfixable here:
+    # quick-xml is only pulled in via plist, and the latest plist (1.9.0)
+    # pins quick-xml ^0.39. plist parses macOS property lists inside Tauri,
+    # never attacker-controlled XML, so the practical risk is negligible.
+    # Revisit: remove once plist releases with quick-xml >= 0.41.
+    "RUSTSEC-2026-0194",
+]

--- a/src/desktop/src-tauri/Cargo.lock
+++ b/src/desktop/src-tauri/Cargo.lock
@@ -2520,9 +2520,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plist"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.13.0",
@@ -2681,9 +2681,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]


### PR DESCRIPTION
The weekly-fresh RUSTSEC-2026-0194 (high, CVSS 7.5) flags quick-xml < 0.41 for quadratic runtime when parsing start tags with many attributes — a DoS on **untrusted** XML input.

**Why not just upgrade:** quick-xml enters the tree only via `plist`, and even the latest plist (1.9.0) pins `quick-xml ^0.39`. The patched range (>=0.41.0) is unreachable until plist bumps upstream.

**What this does:**
- `cargo update -p plist` → plist 1.9.0, quick-xml 0.38.4 → 0.39.4 (closest we can get)
- adds `.cargo/audit.toml` with a documented accepted-risk ignore for this advisory — plist parses macOS property lists inside Tauri, never attacker-controlled XML, so the DoS vector doesn't apply. Includes a revisit note to drop the ignore once plist allows quick-xml 0.41.

This is the accepted-risk mechanism CodeRabbit suggested in #54; declined then for lack of need, warranted now by a genuinely unfixable transitive advisory.